### PR TITLE
Parameters flag in build_loadable_extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,4 +94,5 @@ set(ALL_SOURCES
     src/to_substrait.cpp src/from_substrait.cpp src/substrait-extension.cpp
     ${SUBSTRAIT_SOURCES} ${PROTOBUF_SOURCES})
 
-build_loadable_extension(${TARGET_NAME} ${ALL_SOURCES})
+set(PARAMETERS "-warnings")
+build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${ALL_SOURCES})


### PR DESCRIPTION
This fixes an upcoming PR that introduces the parameters field to the `build_loadable_extension`. This field encoded as a string so as to be extensible in the future, and replaces the (previously borked) IGNORE_WARNINGS field (see duckdb/duckdb#4394).