### PR TITLE
Add single file parquet to substrait

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,7 +30,6 @@ jobs:
         pip uninstall protobuf -y
         pip install --no-binary protobuf protobuf
         pip uninstall duckdb -y
-        pip install duckdb --pre
 
     - name: Update DuckDB submodule
       run: |
@@ -39,7 +38,6 @@ jobs:
 
     - name: Build DuckDB (Python)
       run: BUILD_PYTHON=1 make release
-
 
     - name: Test Python
       run: |

--- a/.github/workflows/sql.yml
+++ b/.github/workflows/sql.yml
@@ -25,7 +25,7 @@ jobs:
         make pull
 
     - name: Build
-      run: make release_bundled
+      run: BUILD_PARQUET=1 make release_bundled
 
     - name: Test
       run: make test_release

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ ifeq (${BUILD_R}, 1)
 	BUILD_FLAGS:=${EXTENSIONS} -DBUILD_R=1
 endif
 
+ifeq (${BUILD_PARQUET}, 1)
+	BUILD_FLAGS:=${EXTENSIONS} -DBUILD_PARQUET_EXTENSION=1
+endif
+
+
 pull:
 	git submodule init
 	git submodule update --recursive --remote

--- a/substrait/from_substrait.cpp
+++ b/substrait/from_substrait.cpp
@@ -423,11 +423,34 @@ SubstraitToDuckDB::TransformAggregateOp(const substrait::Rel &sop) {
 shared_ptr<Relation>
 SubstraitToDuckDB::TransformReadOp(const substrait::Rel &sop) {
   auto &sget = sop.read();
-  if (!sget.has_named_table()) {
-    throw InternalException("Can only scan named tables for now");
+  shared_ptr<Relation> scan;
+  if (sget.has_named_table()) {
+    scan = con.Table(sget.named_table().names(0));
+  } else if (sget.has_local_files()) {
+    auto local_file_items = sget.local_files().items();
+    if (local_file_items.size() > 1) {
+      throw NotImplementedException(
+          "Can't handle more than one file in the read operator of substrait");
+    }
+    auto current_file = local_file_items[0];
+    if (current_file.has_parquet()) {
+      if (current_file.has_uri_file()) {
+        scan = con.ReadParquet(local_file_items[0].uri_file(), false);
+      } else if (current_file.has_uri_path()) {
+        scan = con.ReadParquet(local_file_items[0].uri_path(), false);
+      } else {
+        throw NotImplementedException(
+            "Unsupported type for file path, Only uri_file and uri_path are "
+            "currently supported");
+      }
+    } else {
+      throw NotImplementedException(
+          "Unsupported type of local file for read operator on substrait");
+    }
+  } else {
+    throw NotImplementedException(
+        "Unsupported type of read operator for substrait");
   }
-
-  auto scan = con.Table(sop.read().named_table().names(0));
 
   if (sget.has_filter()) {
     scan =

--- a/substrait/include/to_substrait.hpp
+++ b/substrait/include/to_substrait.hpp
@@ -10,6 +10,7 @@
 #include "duckdb/planner/joinside.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/planner/bound_result_modifier.hpp"
+#include "duckdb/function/table_function.hpp"
 
 namespace duckdb {
 class DuckDBToSubstrait {
@@ -47,6 +48,12 @@ private:
 	substrait::Rel *TransformAggregateGroup(duckdb::LogicalOperator &dop);
 	substrait::Rel *TransformGet(duckdb::LogicalOperator &dop);
 	substrait::Rel *TransformCrossProduct(duckdb::LogicalOperator &dop);
+
+        //! Methods to transform different LogicalGet Types (e.g., Table, Parquet)
+        //! To Substrait;
+        void TransformTableScanToSubstrait(LogicalGet & dget, substrait::ReadRel* sget);
+        void TransformParquetScanToSubstrait(LogicalGet & dget, substrait::ReadRel* sget, BindInfo& bind_info, FunctionData& bind_data);
+
 
 	//! Methods to transform DuckDBConstants to Substrait Expressions
 	void TransformConstant(duckdb::Value &dval, substrait::Expression &sexpr);

--- a/substrait/to_substrait.cpp
+++ b/substrait/to_substrait.cpp
@@ -885,11 +885,77 @@ set<idx_t> GetNotNullConstraintCol(TableCatalogEntry &tbl) {
   return not_null;
 }
 
+void DuckDBToSubstrait::TransformTableScanToSubstrait(
+    LogicalGet &dget, substrait::ReadRel *sget) {
+  auto &table_scan_bind_data = (TableScanBindData &)*dget.bind_data;
+  sget->mutable_named_table()->add_names(table_scan_bind_data.table->name);
+  auto base_schema = new ::substrait::NamedStruct();
+  auto type_info = new substrait::Type_Struct();
+  type_info->set_nullability(substrait::Type_Nullability_NULLABILITY_REQUIRED);
+  auto not_null_constraint =
+      GetNotNullConstraintCol(*table_scan_bind_data.table);
+  for (idx_t i = 0; i < dget.names.size(); i++) {
+    auto cur_type = dget.returned_types[i];
+    if (cur_type.id() == LogicalTypeId::STRUCT) {
+      throw std::runtime_error("Structs are not yet accepted in table scans");
+    }
+    base_schema->add_names(dget.names[i]);
+    auto column_statistics =
+        dget.function.statistics(context, &table_scan_bind_data, i);
+    bool not_null = not_null_constraint.find(i) != not_null_constraint.end();
+    auto new_type = type_info->add_types();
+    *new_type =
+        DuckToSubstraitType(cur_type, column_statistics.get(), not_null);
+  }
+  base_schema->set_allocated_struct_(type_info);
+  sget->set_allocated_base_schema(base_schema);
+}
+
+void DuckDBToSubstrait::TransformParquetScanToSubstrait(
+    LogicalGet &dget, substrait::ReadRel *sget, BindInfo &bind_info,
+    FunctionData &bind_data) {
+  auto files_path = bind_info.GetOptionList<string>("file_path");
+  if (files_path.size() != 1) {
+    throw NotImplementedException(
+        "Substrait Parquet Reader only supports single file");
+  }
+
+  auto parquet_item = sget->mutable_local_files()->add_items();
+  // FIXME: should this be uri or file ogw
+  auto *path = new string();
+  *path = files_path[0];
+  parquet_item->set_allocated_uri_file(path);
+
+  auto parquet_options = parquet_item->mutable_parquet();
+
+  auto base_schema = new ::substrait::NamedStruct();
+  auto type_info = new substrait::Type_Struct();
+  type_info->set_nullability(substrait::Type_Nullability_NULLABILITY_REQUIRED);
+  for (idx_t i = 0; i < dget.names.size(); i++) {
+    auto cur_type = dget.returned_types[i];
+    if (cur_type.id() == LogicalTypeId::STRUCT) {
+      throw std::runtime_error("Structs are not yet accepted in table scans");
+    }
+    base_schema->add_names(dget.names[i]);
+    auto column_statistics = dget.function.statistics(context, &bind_data, i);
+    auto new_type = type_info->add_types();
+    *new_type = DuckToSubstraitType(cur_type, column_statistics.get(), false);
+  }
+  base_schema->set_allocated_struct_(type_info);
+  sget->set_allocated_base_schema(base_schema);
+}
+
 substrait::Rel *DuckDBToSubstrait::TransformGet(LogicalOperator &dop) {
   auto get_rel = new substrait::Rel();
   substrait::Rel *rel = get_rel;
   auto &dget = (LogicalGet &)dop;
-  auto &table_scan_bind_data = (TableScanBindData &)*dget.bind_data;
+
+  if (!dget.function.get_batch_info) {
+    throw NotImplementedException(
+        "This Scanner Type can't be used in substrait because a get batch info "
+        "is not yet implemented");
+  }
+  auto bind_info = dget.function.get_batch_info(dget.bind_data.get());
   auto sget = get_rel->mutable_read();
 
   if (!dget.table_filters.filters.empty()) {
@@ -921,27 +987,18 @@ substrait::Rel *DuckDBToSubstrait::TransformGet(LogicalOperator &dop) {
   }
 
   // Add Table Schema
-  sget->mutable_named_table()->add_names(table_scan_bind_data.table->name);
-  auto base_schema = new ::substrait::NamedStruct();
-  auto type_info = new substrait::Type_Struct();
-  type_info->set_nullability(substrait::Type_Nullability_NULLABILITY_REQUIRED);
-  auto not_null_constraint =
-      GetNotNullConstraintCol(*table_scan_bind_data.table);
-  for (idx_t i = 0; i < dget.names.size(); i++) {
-    auto cur_type = dget.returned_types[i];
-    if (cur_type.id() == LogicalTypeId::STRUCT) {
-      throw std::runtime_error("Structs are not yet accepted in table scans");
-    }
-    base_schema->add_names(dget.names[i]);
-    auto column_statistics =
-        dget.function.statistics(context, &table_scan_bind_data, i);
-    bool not_null = not_null_constraint.find(i) != not_null_constraint.end();
-    auto new_type = type_info->add_types();
-    *new_type =
-        DuckToSubstraitType(cur_type, column_statistics.get(), not_null);
+  switch (bind_info.type) {
+  case ScanType::TABLE:
+    TransformTableScanToSubstrait(dget, sget);
+    break;
+  case ScanType::PARQUET:
+    TransformParquetScanToSubstrait(dget, sget, bind_info, *dget.bind_data);
+    break;
+  default:
+    throw NotImplementedException(
+        "This Scan Type is not yet implement for the to_substrait function");
   }
-  base_schema->set_allocated_struct_(type_info);
-  sget->set_allocated_base_schema(base_schema);
+
   return rel;
 }
 

--- a/test/sql/test_substrait_parquet.test
+++ b/test/sql/test_substrait_parquet.test
@@ -6,6 +6,6 @@ statement ok
 PRAGMA enable_verification
 
 require parquet
-#
-#statement ok
-#CALL get_substrait('SELECT sum(l_extendedprice * l_discount) as revenue FROM parquet_scan(''data/parquet-testing/lineitem-top10000.gzip.parquet'')')
+
+statement ok
+CALL get_substrait('SELECT sum(l_extendedprice * l_discount) as revenue FROM parquet_scan(''data/parquet-testing/lineitem-top10000.gzip.parquet'')')


### PR DESCRIPTION
Part of #3 

Adds the possibility of consuming and producing substrait plans based on parquet files. Currently doesn't support any parquet options and only supports single-file parquet scanners.

Depends on: duckdb/duckdb#5627 being merged.

CC: @richtia and @prmoore77 