### PR TITLE
Re-enable optimizer tests + other misc chores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@
 
 all: release
 
+DUCKDB_DIRECTORY=
+ifndef DUCKDB_DIR
+	DUCKDB_DIRECTORY=duckdb
+else
+	DUCKDB_DIRECTORY=${DUCKDB_DIR}
+endif
+
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJ_DIR := $(dir $(MKFILE_PATH))
 
@@ -92,8 +99,10 @@ test_release_r: release_r
 	cd test/r && R -f test_substrait.R
 
 format:
+	cp ${DUCKDB_DIRECTORY}/.clang-format .
 	find src/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
 	cmake-format -i CMakeLists.txt
+	rm .clang-format
 
 update:
 	git submodule update --remote --merge

--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -21,573 +21,494 @@
 #include "google/protobuf/util/json_util.h"
 
 namespace duckdb {
-const std::unordered_map<std::string, std::string>
-    SubstraitToDuckDB::function_names_remap = {
-        {"modulus", "mod"},        {"std_dev", "stddev"},
-        {"starts_with", "prefix"}, {"ends_with", "suffix"},
-        {"substring", "substr"},   {"char_length", "length"},
-        {"is_nan", "isnan"},       {"is_finite", "isfinite"},
-        {"is_infinite", "isinf"},  {"like", "~~"}};
+const std::unordered_map<std::string, std::string> SubstraitToDuckDB::function_names_remap = {
+    {"modulus", "mod"},      {"std_dev", "stddev"},     {"starts_with", "prefix"},
+    {"ends_with", "suffix"}, {"substring", "substr"},   {"char_length", "length"},
+    {"is_nan", "isnan"},     {"is_finite", "isfinite"}, {"is_infinite", "isinf"},
+    {"like", "~~"}};
 
 std::string &SubstraitToDuckDB::RemapFunctionName(std::string &function_name) {
-  auto it = function_names_remap.find(function_name);
-  if (it != function_names_remap.end()) {
-    function_name = it->second;
-  }
-  return function_name;
+	auto it = function_names_remap.find(function_name);
+	if (it != function_names_remap.end()) {
+		function_name = it->second;
+	}
+	return function_name;
 }
 
-SubstraitToDuckDB::SubstraitToDuckDB(Connection &con_p, string &serialized,
-                                     bool json)
-    : con(con_p) {
-  if (!json) {
-    if (!plan.ParseFromString(serialized)) {
-      throw std::runtime_error(
-          "Was not possible to convert binary into Substrait plan");
-    }
-  } else {
-    if (!google::protobuf::util::JsonStringToMessage(serialized, &plan).ok()) {
-      throw std::runtime_error(
-          "Was not possible to convert binary into Substrait plan");
-    }
-  }
+SubstraitToDuckDB::SubstraitToDuckDB(Connection &con_p, string &serialized, bool json) : con(con_p) {
+	if (!json) {
+		if (!plan.ParseFromString(serialized)) {
+			throw std::runtime_error("Was not possible to convert binary into Substrait plan");
+		}
+	} else {
+		if (!google::protobuf::util::JsonStringToMessage(serialized, &plan).ok()) {
+			throw std::runtime_error("Was not possible to convert binary into Substrait plan");
+		}
+	}
 
-  for (auto &sext : plan.extensions()) {
-    if (!sext.has_extension_function()) {
-      continue;
-    }
-    functions_map[sext.extension_function().function_anchor()] =
-        sext.extension_function().name();
-  }
+	for (auto &sext : plan.extensions()) {
+		if (!sext.has_extension_function()) {
+			continue;
+		}
+		functions_map[sext.extension_function().function_anchor()] = sext.extension_function().name();
+	}
 }
 
-unique_ptr<ParsedExpression>
-SubstraitToDuckDB::TransformLiteralExpr(const substrait::Expression &sexpr) {
-  const auto &slit = sexpr.literal();
-  Value dval;
-  if (slit.has_null()) {
-    dval = Value(LogicalType::SQLNULL);
-    return make_unique<ConstantExpression>(dval);
-  }
-  switch (slit.literal_type_case()) {
-  case substrait::Expression_Literal::LiteralTypeCase::kFp64:
-    dval = Value::DOUBLE(slit.fp64());
-    break;
-  case substrait::Expression_Literal::LiteralTypeCase::kFp32:
-    dval = Value::FLOAT(slit.fp32());
-    break;
-  case substrait::Expression_Literal::LiteralTypeCase::kString:
-    dval = Value(slit.string());
-    break;
-  case substrait::Expression_Literal::LiteralTypeCase::kDecimal: {
-    const auto &substrait_decimal = slit.decimal();
-    auto raw_value = (uint64_t *)substrait_decimal.value().c_str();
-    hugeint_t substrait_value;
-    substrait_value.lower = raw_value[0];
-    substrait_value.upper = raw_value[1];
-    Value val = Value::HUGEINT(substrait_value);
-    auto decimal_type = LogicalType::DECIMAL(substrait_decimal.precision(),
-                                             substrait_decimal.scale());
-    // cast to correct value
-    switch (decimal_type.InternalType()) {
-    case PhysicalType::INT8:
-      dval =
-          Value::DECIMAL(val.GetValue<int8_t>(), substrait_decimal.precision(),
-                         substrait_decimal.scale());
-      break;
-    case PhysicalType::INT16:
-      dval =
-          Value::DECIMAL(val.GetValue<int16_t>(), substrait_decimal.precision(),
-                         substrait_decimal.scale());
-      break;
-    case PhysicalType::INT32:
-      dval =
-          Value::DECIMAL(val.GetValue<int32_t>(), substrait_decimal.precision(),
-                         substrait_decimal.scale());
-      break;
-    case PhysicalType::INT64:
-      dval =
-          Value::DECIMAL(val.GetValue<int64_t>(), substrait_decimal.precision(),
-                         substrait_decimal.scale());
-      break;
-    case PhysicalType::INT128:
-      dval = Value::DECIMAL(substrait_value, substrait_decimal.precision(),
-                            substrait_decimal.scale());
-      break;
-    default:
-      throw InternalException("Not accepted internal type for decimal");
-    }
-    break;
-  }
-  case substrait::Expression_Literal::LiteralTypeCase::kBoolean: {
-    dval = Value(slit.boolean());
-    break;
-  }
-  case substrait::Expression_Literal::LiteralTypeCase::kI8:
-    dval = Value::TINYINT(slit.i8());
-    break;
-  case substrait::Expression_Literal::LiteralTypeCase::kI32:
-    dval = Value::INTEGER(slit.i32());
-    break;
-  case substrait::Expression_Literal::LiteralTypeCase::kI64:
-    dval = Value::BIGINT(slit.i64());
-    break;
-  case substrait::Expression_Literal::LiteralTypeCase::kDate: {
-    date_t date(slit.date());
-    dval = Value::DATE(date);
-    break;
-  }
-  case substrait::Expression_Literal::LiteralTypeCase::kTime: {
-    dtime_t time(slit.time());
-    dval = Value::TIME(time);
-    break;
-  }
-  case substrait::Expression_Literal::LiteralTypeCase::kIntervalYearToMonth: {
-    interval_t interval;
-    interval.months = slit.interval_year_to_month().months();
-    interval.days = 0;
-    interval.micros = 0;
-    dval = Value::INTERVAL(interval);
-    break;
-  }
-  case substrait::Expression_Literal::LiteralTypeCase::kIntervalDayToSecond: {
-    interval_t interval;
-    interval.months = 0;
-    interval.days = slit.interval_day_to_second().days();
-    interval.micros = slit.interval_day_to_second().microseconds();
-    dval = Value::INTERVAL(interval);
-    break;
-  }
-  default:
-    throw InternalException(to_string(slit.literal_type_case()));
-  }
-  return make_unique<ConstantExpression>(dval);
+unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformLiteralExpr(const substrait::Expression &sexpr) {
+	const auto &slit = sexpr.literal();
+	Value dval;
+	if (slit.has_null()) {
+		dval = Value(LogicalType::SQLNULL);
+		return make_unique<ConstantExpression>(dval);
+	}
+	switch (slit.literal_type_case()) {
+	case substrait::Expression_Literal::LiteralTypeCase::kFp64:
+		dval = Value::DOUBLE(slit.fp64());
+		break;
+	case substrait::Expression_Literal::LiteralTypeCase::kFp32:
+		dval = Value::FLOAT(slit.fp32());
+		break;
+	case substrait::Expression_Literal::LiteralTypeCase::kString:
+		dval = Value(slit.string());
+		break;
+	case substrait::Expression_Literal::LiteralTypeCase::kDecimal: {
+		const auto &substrait_decimal = slit.decimal();
+		auto raw_value = (uint64_t *)substrait_decimal.value().c_str();
+		hugeint_t substrait_value;
+		substrait_value.lower = raw_value[0];
+		substrait_value.upper = raw_value[1];
+		Value val = Value::HUGEINT(substrait_value);
+		auto decimal_type = LogicalType::DECIMAL(substrait_decimal.precision(), substrait_decimal.scale());
+		// cast to correct value
+		switch (decimal_type.InternalType()) {
+		case PhysicalType::INT8:
+			dval = Value::DECIMAL(val.GetValue<int8_t>(), substrait_decimal.precision(), substrait_decimal.scale());
+			break;
+		case PhysicalType::INT16:
+			dval = Value::DECIMAL(val.GetValue<int16_t>(), substrait_decimal.precision(), substrait_decimal.scale());
+			break;
+		case PhysicalType::INT32:
+			dval = Value::DECIMAL(val.GetValue<int32_t>(), substrait_decimal.precision(), substrait_decimal.scale());
+			break;
+		case PhysicalType::INT64:
+			dval = Value::DECIMAL(val.GetValue<int64_t>(), substrait_decimal.precision(), substrait_decimal.scale());
+			break;
+		case PhysicalType::INT128:
+			dval = Value::DECIMAL(substrait_value, substrait_decimal.precision(), substrait_decimal.scale());
+			break;
+		default:
+			throw InternalException("Not accepted internal type for decimal");
+		}
+		break;
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kBoolean: {
+		dval = Value(slit.boolean());
+		break;
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kI8:
+		dval = Value::TINYINT(slit.i8());
+		break;
+	case substrait::Expression_Literal::LiteralTypeCase::kI32:
+		dval = Value::INTEGER(slit.i32());
+		break;
+	case substrait::Expression_Literal::LiteralTypeCase::kI64:
+		dval = Value::BIGINT(slit.i64());
+		break;
+	case substrait::Expression_Literal::LiteralTypeCase::kDate: {
+		date_t date(slit.date());
+		dval = Value::DATE(date);
+		break;
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kTime: {
+		dtime_t time(slit.time());
+		dval = Value::TIME(time);
+		break;
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kIntervalYearToMonth: {
+		interval_t interval;
+		interval.months = slit.interval_year_to_month().months();
+		interval.days = 0;
+		interval.micros = 0;
+		dval = Value::INTERVAL(interval);
+		break;
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kIntervalDayToSecond: {
+		interval_t interval;
+		interval.months = 0;
+		interval.days = slit.interval_day_to_second().days();
+		interval.micros = slit.interval_day_to_second().microseconds();
+		dval = Value::INTERVAL(interval);
+		break;
+	}
+	default:
+		throw InternalException(to_string(slit.literal_type_case()));
+	}
+	return make_unique<ConstantExpression>(dval);
 }
 
-unique_ptr<ParsedExpression>
-SubstraitToDuckDB::TransformSelectionExpr(const substrait::Expression &sexpr) {
-  if (!sexpr.selection().has_direct_reference() ||
-      !sexpr.selection().direct_reference().has_struct_field()) {
-    throw InternalException(
-        "Can only have direct struct references in selections");
-  }
-  return make_unique<PositionalReferenceExpression>(
-      sexpr.selection().direct_reference().struct_field().field() + 1);
+unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformSelectionExpr(const substrait::Expression &sexpr) {
+	if (!sexpr.selection().has_direct_reference() || !sexpr.selection().direct_reference().has_struct_field()) {
+		throw InternalException("Can only have direct struct references in selections");
+	}
+	return make_unique<PositionalReferenceExpression>(sexpr.selection().direct_reference().struct_field().field() + 1);
 }
 
-unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformScalarFunctionExpr(
-    const substrait::Expression &sexpr) {
-  auto function_name =
-      FindFunction(sexpr.scalar_function().function_reference());
-  vector<unique_ptr<ParsedExpression>> children;
-  for (auto &sarg : sexpr.scalar_function().arguments()) {
-    children.push_back(TransformExpr(sarg.value()));
-  }
-  // string compare galore
-  // TODO simplify this
-  if (function_name == "and") {
-    return make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_AND,
-                                              move(children));
-  } else if (function_name == "or") {
-    return make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_OR,
-                                              move(children));
-  } else if (function_name == "lt") {
-    D_ASSERT(children.size() == 2);
-    return make_unique<ComparisonExpression>(
-        ExpressionType::COMPARE_LESSTHAN, move(children[0]), move(children[1]));
-  } else if (function_name == "equal") {
-    D_ASSERT(children.size() == 2);
-    return make_unique<ComparisonExpression>(
-        ExpressionType::COMPARE_EQUAL, move(children[0]), move(children[1]));
-  } else if (function_name == "not_equal") {
-    D_ASSERT(children.size() == 2);
-    return make_unique<ComparisonExpression>(
-        ExpressionType::COMPARE_NOTEQUAL, move(children[0]), move(children[1]));
-  } else if (function_name == "lte") {
-    D_ASSERT(children.size() == 2);
-    return make_unique<ComparisonExpression>(
-        ExpressionType::COMPARE_LESSTHANOREQUALTO, move(children[0]),
-        move(children[1]));
-  } else if (function_name == "gte") {
-    D_ASSERT(children.size() == 2);
-    return make_unique<ComparisonExpression>(
-        ExpressionType::COMPARE_GREATERTHANOREQUALTO, move(children[0]),
-        move(children[1]));
-  } else if (function_name == "gt") {
-    D_ASSERT(children.size() == 2);
-    return make_unique<ComparisonExpression>(
-        ExpressionType::COMPARE_GREATERTHAN, move(children[0]),
-        move(children[1]));
-  } else if (function_name == "is_not_null") {
-    D_ASSERT(children.size() == 1);
-    return make_unique<OperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL,
-                                           move(children[0]));
-  } else if (function_name == "is_null") {
-    D_ASSERT(children.size() == 1);
-    return make_unique<OperatorExpression>(ExpressionType::OPERATOR_IS_NULL,
-                                           move(children[0]));
-  } else if (function_name == "not") {
-    D_ASSERT(children.size() == 1);
-    return make_unique<OperatorExpression>(ExpressionType::OPERATOR_NOT,
-                                           move(children[0]));
-  } else if (function_name == "is_not_distinct_from") {
-    D_ASSERT(children.size() == 2);
-    return make_unique<ComparisonExpression>(
-        ExpressionType::COMPARE_NOT_DISTINCT_FROM, move(children[0]),
-        move(children[1]));
-  } else if (function_name == "between") {
-    // FIXME: ADD between to substrait extension
-    D_ASSERT(children.size() == 3);
-    return make_unique<BetweenExpression>(move(children[0]), move(children[1]),
-                                          move(children[2]));
-  }
+unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformScalarFunctionExpr(const substrait::Expression &sexpr) {
+	auto function_name = FindFunction(sexpr.scalar_function().function_reference());
+	vector<unique_ptr<ParsedExpression>> children;
+	for (auto &sarg : sexpr.scalar_function().arguments()) {
+		children.push_back(TransformExpr(sarg.value()));
+	}
+	// string compare galore
+	// TODO simplify this
+	if (function_name == "and") {
+		return make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_AND, move(children));
+	} else if (function_name == "or") {
+		return make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_OR, move(children));
+	} else if (function_name == "lt") {
+		D_ASSERT(children.size() == 2);
+		return make_unique<ComparisonExpression>(ExpressionType::COMPARE_LESSTHAN, move(children[0]),
+		                                         move(children[1]));
+	} else if (function_name == "equal") {
+		D_ASSERT(children.size() == 2);
+		return make_unique<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, move(children[0]), move(children[1]));
+	} else if (function_name == "not_equal") {
+		D_ASSERT(children.size() == 2);
+		return make_unique<ComparisonExpression>(ExpressionType::COMPARE_NOTEQUAL, move(children[0]),
+		                                         move(children[1]));
+	} else if (function_name == "lte") {
+		D_ASSERT(children.size() == 2);
+		return make_unique<ComparisonExpression>(ExpressionType::COMPARE_LESSTHANOREQUALTO, move(children[0]),
+		                                         move(children[1]));
+	} else if (function_name == "gte") {
+		D_ASSERT(children.size() == 2);
+		return make_unique<ComparisonExpression>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, move(children[0]),
+		                                         move(children[1]));
+	} else if (function_name == "gt") {
+		D_ASSERT(children.size() == 2);
+		return make_unique<ComparisonExpression>(ExpressionType::COMPARE_GREATERTHAN, move(children[0]),
+		                                         move(children[1]));
+	} else if (function_name == "is_not_null") {
+		D_ASSERT(children.size() == 1);
+		return make_unique<OperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, move(children[0]));
+	} else if (function_name == "is_null") {
+		D_ASSERT(children.size() == 1);
+		return make_unique<OperatorExpression>(ExpressionType::OPERATOR_IS_NULL, move(children[0]));
+	} else if (function_name == "not") {
+		D_ASSERT(children.size() == 1);
+		return make_unique<OperatorExpression>(ExpressionType::OPERATOR_NOT, move(children[0]));
+	} else if (function_name == "is_not_distinct_from") {
+		D_ASSERT(children.size() == 2);
+		return make_unique<ComparisonExpression>(ExpressionType::COMPARE_NOT_DISTINCT_FROM, move(children[0]),
+		                                         move(children[1]));
+	} else if (function_name == "between") {
+		// FIXME: ADD between to substrait extension
+		D_ASSERT(children.size() == 3);
+		return make_unique<BetweenExpression>(move(children[0]), move(children[1]), move(children[2]));
+	}
 
-  return make_unique<FunctionExpression>(RemapFunctionName(function_name),
-                                         move(children));
+	return make_unique<FunctionExpression>(RemapFunctionName(function_name), move(children));
 }
 
-unique_ptr<ParsedExpression>
-SubstraitToDuckDB::TransformIfThenExpr(const substrait::Expression &sexpr) {
-  const auto &scase = sexpr.if_then();
-  auto dcase = make_unique<CaseExpression>();
-  for (const auto &sif : scase.ifs()) {
-    CaseCheck dif;
-    dif.when_expr = TransformExpr(sif.if_());
-    dif.then_expr = TransformExpr(sif.then());
-    dcase->case_checks.push_back(move(dif));
-  }
-  dcase->else_expr = TransformExpr(scase.else_());
-  return move(dcase);
+unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformIfThenExpr(const substrait::Expression &sexpr) {
+	const auto &scase = sexpr.if_then();
+	auto dcase = make_unique<CaseExpression>();
+	for (const auto &sif : scase.ifs()) {
+		CaseCheck dif;
+		dif.when_expr = TransformExpr(sif.if_());
+		dif.then_expr = TransformExpr(sif.then());
+		dcase->case_checks.push_back(move(dif));
+	}
+	dcase->else_expr = TransformExpr(scase.else_());
+	return move(dcase);
 }
 
-LogicalType
-SubstraitToDuckDB::SubstraitToDuckType(const ::substrait::Type &s_type) {
+LogicalType SubstraitToDuckDB::SubstraitToDuckType(const ::substrait::Type &s_type) {
 
-  if (s_type.has_bool_()) {
-    return LogicalType(LogicalTypeId::BOOLEAN);
-  } else if (s_type.has_i16()) {
-    return LogicalType(LogicalTypeId::SMALLINT);
-  } else if (s_type.has_i32()) {
-    return LogicalType(LogicalTypeId::INTEGER);
-  } else if (s_type.has_decimal()) {
-    auto &s_decimal_type = s_type.decimal();
-    return LogicalType::DECIMAL(s_decimal_type.precision(),
-                                s_decimal_type.scale());
-  } else if (s_type.has_i64()) {
-    return LogicalType(LogicalTypeId::BIGINT);
-  } else if (s_type.has_date()) {
-    return LogicalType(LogicalTypeId::DATE);
-  } else if (s_type.has_varchar() || s_type.has_string()) {
-    return LogicalType(LogicalTypeId::VARCHAR);
-  } else if (s_type.has_fp64()) {
-    return LogicalType(LogicalTypeId::DOUBLE);
-  } else {
-    throw InternalException("Substrait type not yet supported");
-  }
+	if (s_type.has_bool_()) {
+		return LogicalType(LogicalTypeId::BOOLEAN);
+	} else if (s_type.has_i16()) {
+		return LogicalType(LogicalTypeId::SMALLINT);
+	} else if (s_type.has_i32()) {
+		return LogicalType(LogicalTypeId::INTEGER);
+	} else if (s_type.has_decimal()) {
+		auto &s_decimal_type = s_type.decimal();
+		return LogicalType::DECIMAL(s_decimal_type.precision(), s_decimal_type.scale());
+	} else if (s_type.has_i64()) {
+		return LogicalType(LogicalTypeId::BIGINT);
+	} else if (s_type.has_date()) {
+		return LogicalType(LogicalTypeId::DATE);
+	} else if (s_type.has_varchar() || s_type.has_string()) {
+		return LogicalType(LogicalTypeId::VARCHAR);
+	} else if (s_type.has_fp64()) {
+		return LogicalType(LogicalTypeId::DOUBLE);
+	} else {
+		throw InternalException("Substrait type not yet supported");
+	}
 }
 
-unique_ptr<ParsedExpression>
-SubstraitToDuckDB::TransformCastExpr(const substrait::Expression &sexpr) {
-  const auto &scast = sexpr.cast();
-  auto cast_type = SubstraitToDuckType(scast.type());
-  auto cast_child = TransformExpr(scast.input());
-  return make_unique<CastExpression>(cast_type, move(cast_child));
+unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformCastExpr(const substrait::Expression &sexpr) {
+	const auto &scast = sexpr.cast();
+	auto cast_type = SubstraitToDuckType(scast.type());
+	auto cast_child = TransformExpr(scast.input());
+	return make_unique<CastExpression>(cast_type, move(cast_child));
 }
 
-unique_ptr<ParsedExpression>
-SubstraitToDuckDB::TransformInExpr(const substrait::Expression &sexpr) {
-  const auto &substrait_in = sexpr.singular_or_list();
+unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformInExpr(const substrait::Expression &sexpr) {
+	const auto &substrait_in = sexpr.singular_or_list();
 
-  vector<unique_ptr<ParsedExpression>> values;
-  values.emplace_back(TransformExpr(substrait_in.value()));
+	vector<unique_ptr<ParsedExpression>> values;
+	values.emplace_back(TransformExpr(substrait_in.value()));
 
-  for (idx_t i = 0; i < (idx_t)substrait_in.options_size(); i++) {
-    values.emplace_back(TransformExpr(substrait_in.options(i)));
-  }
+	for (idx_t i = 0; i < (idx_t)substrait_in.options_size(); i++) {
+		values.emplace_back(TransformExpr(substrait_in.options(i)));
+	}
 
-  return make_unique<OperatorExpression>(ExpressionType::COMPARE_IN,
-                                         move(values));
+	return make_unique<OperatorExpression>(ExpressionType::COMPARE_IN, move(values));
 }
 
-unique_ptr<ParsedExpression>
-SubstraitToDuckDB::TransformExpr(const substrait::Expression &sexpr) {
-  switch (sexpr.rex_type_case()) {
-  case substrait::Expression::RexTypeCase::kLiteral:
-    return TransformLiteralExpr(sexpr);
-  case substrait::Expression::RexTypeCase::kSelection:
-    return TransformSelectionExpr(sexpr);
-  case substrait::Expression::RexTypeCase::kScalarFunction:
-    return TransformScalarFunctionExpr(sexpr);
-  case substrait::Expression::RexTypeCase::kIfThen:
-    return TransformIfThenExpr(sexpr);
-  case substrait::Expression::RexTypeCase::kCast:
-    return TransformCastExpr(sexpr);
-  case substrait::Expression::RexTypeCase::kSingularOrList:
-    return TransformInExpr(sexpr);
-  case substrait::Expression::RexTypeCase::kSubquery:
-  default:
-    throw InternalException("Unsupported expression type " +
-                            to_string(sexpr.rex_type_case()));
-  }
+unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformExpr(const substrait::Expression &sexpr) {
+	switch (sexpr.rex_type_case()) {
+	case substrait::Expression::RexTypeCase::kLiteral:
+		return TransformLiteralExpr(sexpr);
+	case substrait::Expression::RexTypeCase::kSelection:
+		return TransformSelectionExpr(sexpr);
+	case substrait::Expression::RexTypeCase::kScalarFunction:
+		return TransformScalarFunctionExpr(sexpr);
+	case substrait::Expression::RexTypeCase::kIfThen:
+		return TransformIfThenExpr(sexpr);
+	case substrait::Expression::RexTypeCase::kCast:
+		return TransformCastExpr(sexpr);
+	case substrait::Expression::RexTypeCase::kSingularOrList:
+		return TransformInExpr(sexpr);
+	case substrait::Expression::RexTypeCase::kSubquery:
+	default:
+		throw InternalException("Unsupported expression type " + to_string(sexpr.rex_type_case()));
+	}
 }
 
 string SubstraitToDuckDB::FindFunction(uint64_t id) {
-  if (functions_map.find(id) == functions_map.end()) {
-    throw InternalException("Could not find aggregate function " +
-                            to_string(id));
-  }
-  return functions_map[id];
+	if (functions_map.find(id) == functions_map.end()) {
+		throw InternalException("Could not find aggregate function " + to_string(id));
+	}
+	return functions_map[id];
 }
 
-OrderByNode
-SubstraitToDuckDB::TransformOrder(const substrait::SortField &sordf) {
+OrderByNode SubstraitToDuckDB::TransformOrder(const substrait::SortField &sordf) {
 
-  OrderType dordertype;
-  OrderByNullType dnullorder;
+	OrderType dordertype;
+	OrderByNullType dnullorder;
 
-  switch (sordf.direction()) {
-  case substrait::SortField_SortDirection::
-      SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_FIRST:
-    dordertype = OrderType::ASCENDING;
-    dnullorder = OrderByNullType::NULLS_FIRST;
-    break;
-  case substrait::SortField_SortDirection::
-      SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_LAST:
-    dordertype = OrderType::ASCENDING;
-    dnullorder = OrderByNullType::NULLS_LAST;
-    break;
-  case substrait::SortField_SortDirection::
-      SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_FIRST:
-    dordertype = OrderType::DESCENDING;
-    dnullorder = OrderByNullType::NULLS_FIRST;
-    break;
-  case substrait::SortField_SortDirection::
-      SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST:
-    dordertype = OrderType::DESCENDING;
-    dnullorder = OrderByNullType::NULLS_LAST;
-    break;
-  default:
-    throw InternalException("Unsupported ordering " +
-                            to_string(sordf.direction()));
-  }
+	switch (sordf.direction()) {
+	case substrait::SortField_SortDirection::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_FIRST:
+		dordertype = OrderType::ASCENDING;
+		dnullorder = OrderByNullType::NULLS_FIRST;
+		break;
+	case substrait::SortField_SortDirection::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_LAST:
+		dordertype = OrderType::ASCENDING;
+		dnullorder = OrderByNullType::NULLS_LAST;
+		break;
+	case substrait::SortField_SortDirection::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_FIRST:
+		dordertype = OrderType::DESCENDING;
+		dnullorder = OrderByNullType::NULLS_FIRST;
+		break;
+	case substrait::SortField_SortDirection::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST:
+		dordertype = OrderType::DESCENDING;
+		dnullorder = OrderByNullType::NULLS_LAST;
+		break;
+	default:
+		throw InternalException("Unsupported ordering " + to_string(sordf.direction()));
+	}
 
-  return {dordertype, dnullorder, TransformExpr(sordf.expr())};
+	return {dordertype, dnullorder, TransformExpr(sordf.expr())};
 }
 
-shared_ptr<Relation>
-SubstraitToDuckDB::TransformJoinOp(const substrait::Rel &sop) {
-  auto &sjoin = sop.join();
+shared_ptr<Relation> SubstraitToDuckDB::TransformJoinOp(const substrait::Rel &sop) {
+	auto &sjoin = sop.join();
 
-  JoinType djointype;
-  switch (sjoin.type()) {
-  case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_INNER:
-    djointype = JoinType::INNER;
-    break;
-  case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT:
-    djointype = JoinType::LEFT;
-    break;
-  case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT:
-    djointype = JoinType::RIGHT;
-    break;
-  case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_SINGLE:
-    djointype = JoinType::SINGLE;
-    break;
-  case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_SEMI:
-    djointype = JoinType::SEMI;
-    break;
-  default:
-    throw InternalException("Unsupported join type");
-  }
-  unique_ptr<ParsedExpression> join_condition =
-      TransformExpr(sjoin.expression());
-  return make_shared<JoinRelation>(TransformOp(sjoin.left())->Alias("left"),
-                                   TransformOp(sjoin.right())->Alias("right"),
-                                   move(join_condition), djointype);
+	JoinType djointype;
+	switch (sjoin.type()) {
+	case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_INNER:
+		djointype = JoinType::INNER;
+		break;
+	case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT:
+		djointype = JoinType::LEFT;
+		break;
+	case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT:
+		djointype = JoinType::RIGHT;
+		break;
+	case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_SINGLE:
+		djointype = JoinType::SINGLE;
+		break;
+	case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_SEMI:
+		djointype = JoinType::SEMI;
+		break;
+	default:
+		throw InternalException("Unsupported join type");
+	}
+	unique_ptr<ParsedExpression> join_condition = TransformExpr(sjoin.expression());
+	return make_shared<JoinRelation>(TransformOp(sjoin.left())->Alias("left"),
+	                                 TransformOp(sjoin.right())->Alias("right"), move(join_condition), djointype);
 }
 
-shared_ptr<Relation>
-SubstraitToDuckDB::TransformCrossProductOp(const substrait::Rel &sop) {
-  auto &sub_cross = sop.cross();
+shared_ptr<Relation> SubstraitToDuckDB::TransformCrossProductOp(const substrait::Rel &sop) {
+	auto &sub_cross = sop.cross();
 
-  return make_shared<CrossProductRelation>(
-      TransformOp(sub_cross.left())->Alias("left"),
-      TransformOp(sub_cross.right())->Alias("right"));
+	return make_shared<CrossProductRelation>(TransformOp(sub_cross.left())->Alias("left"),
+	                                         TransformOp(sub_cross.right())->Alias("right"));
 }
 
-shared_ptr<Relation>
-SubstraitToDuckDB::TransformFetchOp(const substrait::Rel &sop) {
-  auto &slimit = sop.fetch();
-  return make_shared<LimitRelation>(TransformOp(slimit.input()), slimit.count(),
-                                    slimit.offset());
+shared_ptr<Relation> SubstraitToDuckDB::TransformFetchOp(const substrait::Rel &sop) {
+	auto &slimit = sop.fetch();
+	return make_shared<LimitRelation>(TransformOp(slimit.input()), slimit.count(), slimit.offset());
 }
 
-shared_ptr<Relation>
-SubstraitToDuckDB::TransformFilterOp(const substrait::Rel &sop) {
-  auto &sfilter = sop.filter();
-  return make_shared<FilterRelation>(TransformOp(sfilter.input()),
-                                     TransformExpr(sfilter.condition()));
+shared_ptr<Relation> SubstraitToDuckDB::TransformFilterOp(const substrait::Rel &sop) {
+	auto &sfilter = sop.filter();
+	return make_shared<FilterRelation>(TransformOp(sfilter.input()), TransformExpr(sfilter.condition()));
 }
 
-shared_ptr<Relation>
-SubstraitToDuckDB::TransformProjectOp(const substrait::Rel &sop) {
-  vector<unique_ptr<ParsedExpression>> expressions;
-  for (auto &sexpr : sop.project().expressions()) {
-    expressions.push_back(TransformExpr(sexpr));
-  }
+shared_ptr<Relation> SubstraitToDuckDB::TransformProjectOp(const substrait::Rel &sop) {
+	vector<unique_ptr<ParsedExpression>> expressions;
+	for (auto &sexpr : sop.project().expressions()) {
+		expressions.push_back(TransformExpr(sexpr));
+	}
 
-  vector<string> mock_aliases;
-  for (size_t i = 0; i < expressions.size(); i++) {
-    mock_aliases.push_back("expr_" + to_string(i));
-  }
-  return make_shared<ProjectionRelation>(TransformOp(sop.project().input()),
-                                         move(expressions), move(mock_aliases));
+	vector<string> mock_aliases;
+	for (size_t i = 0; i < expressions.size(); i++) {
+		mock_aliases.push_back("expr_" + to_string(i));
+	}
+	return make_shared<ProjectionRelation>(TransformOp(sop.project().input()), move(expressions), move(mock_aliases));
 }
 
-shared_ptr<Relation>
-SubstraitToDuckDB::TransformAggregateOp(const substrait::Rel &sop) {
-  vector<unique_ptr<ParsedExpression>> groups, expressions;
+shared_ptr<Relation> SubstraitToDuckDB::TransformAggregateOp(const substrait::Rel &sop) {
+	vector<unique_ptr<ParsedExpression>> groups, expressions;
 
-  if (sop.aggregate().groupings_size() > 0) {
-    for (auto &sgrp : sop.aggregate().groupings()) {
-      for (auto &sgrpexpr : sgrp.grouping_expressions()) {
-        groups.push_back(TransformExpr(sgrpexpr));
-        expressions.push_back(TransformExpr(sgrpexpr));
-      }
-    }
-  }
+	if (sop.aggregate().groupings_size() > 0) {
+		for (auto &sgrp : sop.aggregate().groupings()) {
+			for (auto &sgrpexpr : sgrp.grouping_expressions()) {
+				groups.push_back(TransformExpr(sgrpexpr));
+				expressions.push_back(TransformExpr(sgrpexpr));
+			}
+		}
+	}
 
-  for (auto &smeas : sop.aggregate().measures()) {
-    vector<unique_ptr<ParsedExpression>> children;
-    for (auto &sarg : smeas.measure().arguments()) {
-      children.push_back(TransformExpr(sarg.value()));
-    }
-    auto function_name = FindFunction(smeas.measure().function_reference());
-    if (function_name == "count" && children.empty()) {
-      function_name = "count_star";
-    }
-    expressions.push_back(make_unique<FunctionExpression>(
-        RemapFunctionName(function_name), move(children)));
-  }
+	for (auto &smeas : sop.aggregate().measures()) {
+		vector<unique_ptr<ParsedExpression>> children;
+		for (auto &sarg : smeas.measure().arguments()) {
+			children.push_back(TransformExpr(sarg.value()));
+		}
+		auto function_name = FindFunction(smeas.measure().function_reference());
+		if (function_name == "count" && children.empty()) {
+			function_name = "count_star";
+		}
+		expressions.push_back(make_unique<FunctionExpression>(RemapFunctionName(function_name), move(children)));
+	}
 
-  return make_shared<AggregateRelation>(TransformOp(sop.aggregate().input()),
-                                        move(expressions), move(groups));
+	return make_shared<AggregateRelation>(TransformOp(sop.aggregate().input()), move(expressions), move(groups));
 }
 
-shared_ptr<Relation>
-SubstraitToDuckDB::TransformReadOp(const substrait::Rel &sop) {
-  auto &sget = sop.read();
-  shared_ptr<Relation> scan;
-  if (sget.has_named_table()) {
-    // If we can't find a table with that name, let's try a view.
-    try {
-      scan = con.Table(sget.named_table().names(0));
-    } catch (...) {
-      scan = con.View(sget.named_table().names(0));
-    }
-  } else if (sget.has_local_files()) {
-    auto local_file_items = sget.local_files().items();
-    if (local_file_items.size() > 1) {
-      throw NotImplementedException(
-          "Can't handle more than one file in the read operator of substrait");
-    }
-    auto current_file = local_file_items[0];
-    if (current_file.has_parquet()) {
-      if (current_file.has_uri_file()) {
-        scan = con.ReadParquet(local_file_items[0].uri_file(), false);
-      } else if (current_file.has_uri_path()) {
-        scan = con.ReadParquet(local_file_items[0].uri_path(), false);
-      } else {
-        throw NotImplementedException(
-            "Unsupported type for file path, Only uri_file and uri_path are "
-            "currently supported");
-      }
-    } else {
-      throw NotImplementedException(
-          "Unsupported type of local file for read operator on substrait");
-    }
-  } else {
-    throw NotImplementedException(
-        "Unsupported type of read operator for substrait");
-  }
+shared_ptr<Relation> SubstraitToDuckDB::TransformReadOp(const substrait::Rel &sop) {
+	auto &sget = sop.read();
+	shared_ptr<Relation> scan;
+	if (sget.has_named_table()) {
+		// If we can't find a table with that name, let's try a view.
+		try {
+			scan = con.Table(sget.named_table().names(0));
+		} catch (...) {
+			scan = con.View(sget.named_table().names(0));
+		}
+	} else if (sget.has_local_files()) {
+		auto local_file_items = sget.local_files().items();
+		if (local_file_items.size() > 1) {
+			throw NotImplementedException("Can't handle more than one file in the read operator of substrait");
+		}
+		auto current_file = local_file_items[0];
+		if (current_file.has_parquet()) {
+			if (current_file.has_uri_file()) {
+				scan = con.ReadParquet(local_file_items[0].uri_file(), false);
+			} else if (current_file.has_uri_path()) {
+				scan = con.ReadParquet(local_file_items[0].uri_path(), false);
+			} else {
+				throw NotImplementedException("Unsupported type for file path, Only uri_file and uri_path are "
+				                              "currently supported");
+			}
+		} else {
+			throw NotImplementedException("Unsupported type of local file for read operator on substrait");
+		}
+	} else {
+		throw NotImplementedException("Unsupported type of read operator for substrait");
+	}
 
-  if (sget.has_filter()) {
-    scan =
-        make_shared<FilterRelation>(move(scan), TransformExpr(sget.filter()));
-  }
+	if (sget.has_filter()) {
+		scan = make_shared<FilterRelation>(move(scan), TransformExpr(sget.filter()));
+	}
 
-  if (sget.has_projection()) {
-    vector<unique_ptr<ParsedExpression>> expressions;
-    vector<string> aliases;
-    idx_t expr_idx = 0;
-    for (auto &sproj : sget.projection().select().struct_items()) {
-      // FIXME how to get actually alias?
-      aliases.push_back("expr_" + to_string(expr_idx++));
-      // TODO make sure nothing else is in there
-      expressions.push_back(
-          make_unique<PositionalReferenceExpression>(sproj.field() + 1));
-    }
+	if (sget.has_projection()) {
+		vector<unique_ptr<ParsedExpression>> expressions;
+		vector<string> aliases;
+		idx_t expr_idx = 0;
+		for (auto &sproj : sget.projection().select().struct_items()) {
+			// FIXME how to get actually alias?
+			aliases.push_back("expr_" + to_string(expr_idx++));
+			// TODO make sure nothing else is in there
+			expressions.push_back(make_unique<PositionalReferenceExpression>(sproj.field() + 1));
+		}
 
-    scan = make_shared<ProjectionRelation>(move(scan), move(expressions),
-                                           move(aliases));
-  }
+		scan = make_shared<ProjectionRelation>(move(scan), move(expressions), move(aliases));
+	}
 
-  return scan;
+	return scan;
 }
 
-shared_ptr<Relation>
-SubstraitToDuckDB::TransformSortOp(const substrait::Rel &sop) {
-  vector<OrderByNode> order_nodes;
-  for (auto &sordf : sop.sort().sorts()) {
-    order_nodes.push_back(TransformOrder(sordf));
-  }
-  return make_shared<OrderRelation>(TransformOp(sop.sort().input()),
-                                    move(order_nodes));
+shared_ptr<Relation> SubstraitToDuckDB::TransformSortOp(const substrait::Rel &sop) {
+	vector<OrderByNode> order_nodes;
+	for (auto &sordf : sop.sort().sorts()) {
+		order_nodes.push_back(TransformOrder(sordf));
+	}
+	return make_shared<OrderRelation>(TransformOp(sop.sort().input()), move(order_nodes));
 }
 shared_ptr<Relation> SubstraitToDuckDB::TransformOp(const substrait::Rel &sop) {
-  switch (sop.rel_type_case()) {
-  case substrait::Rel::RelTypeCase::kJoin:
-    return TransformJoinOp(sop);
-  case substrait::Rel::RelTypeCase::kCross:
-    return TransformCrossProductOp(sop);
-  case substrait::Rel::RelTypeCase::kFetch:
-    return TransformFetchOp(sop);
-  case substrait::Rel::RelTypeCase::kFilter:
-    return TransformFilterOp(sop);
-  case substrait::Rel::RelTypeCase::kProject:
-    return TransformProjectOp(sop);
-  case substrait::Rel::RelTypeCase::kAggregate:
-    return TransformAggregateOp(sop);
-  case substrait::Rel::RelTypeCase::kRead:
-    return TransformReadOp(sop);
-  case substrait::Rel::RelTypeCase::kSort:
-    return TransformSortOp(sop);
-  default:
-    throw InternalException("Unsupported relation type " +
-                            to_string(sop.rel_type_case()));
-  }
+	switch (sop.rel_type_case()) {
+	case substrait::Rel::RelTypeCase::kJoin:
+		return TransformJoinOp(sop);
+	case substrait::Rel::RelTypeCase::kCross:
+		return TransformCrossProductOp(sop);
+	case substrait::Rel::RelTypeCase::kFetch:
+		return TransformFetchOp(sop);
+	case substrait::Rel::RelTypeCase::kFilter:
+		return TransformFilterOp(sop);
+	case substrait::Rel::RelTypeCase::kProject:
+		return TransformProjectOp(sop);
+	case substrait::Rel::RelTypeCase::kAggregate:
+		return TransformAggregateOp(sop);
+	case substrait::Rel::RelTypeCase::kRead:
+		return TransformReadOp(sop);
+	case substrait::Rel::RelTypeCase::kSort:
+		return TransformSortOp(sop);
+	default:
+		throw InternalException("Unsupported relation type " + to_string(sop.rel_type_case()));
+	}
 }
 
-shared_ptr<Relation>
-SubstraitToDuckDB::TransformRootOp(const substrait::RelRoot &sop) {
-  vector<string> aliases;
-  auto column_names = sop.names();
-  vector<unique_ptr<ParsedExpression>> expressions;
-  int id = 1;
-  for (auto &column_name : column_names) {
-    aliases.push_back(column_name);
-    expressions.push_back(make_unique<PositionalReferenceExpression>(id++));
-  }
-  return make_shared<ProjectionRelation>(TransformOp(sop.input()),
-                                         move(expressions), aliases);
+shared_ptr<Relation> SubstraitToDuckDB::TransformRootOp(const substrait::RelRoot &sop) {
+	vector<string> aliases;
+	auto column_names = sop.names();
+	vector<unique_ptr<ParsedExpression>> expressions;
+	int id = 1;
+	for (auto &column_name : column_names) {
+		aliases.push_back(column_name);
+		expressions.push_back(make_unique<PositionalReferenceExpression>(id++));
+	}
+	return make_shared<ProjectionRelation>(TransformOp(sop.input()), move(expressions), aliases);
 }
 
 shared_ptr<Relation> SubstraitToDuckDB::TransformPlan() {
-  if (plan.relations().empty()) {
-    throw InvalidInputException(
-        "Substrait Plan does not have a SELECT statement");
-  }
-  auto d_plan = TransformRootOp(plan.relations(0).root());
-  return d_plan;
+	if (plan.relations().empty()) {
+		throw InvalidInputException("Substrait Plan does not have a SELECT statement");
+	}
+	auto d_plan = TransformRootOp(plan.relations(0).root());
+	return d_plan;
 }
 
 } // namespace duckdb

--- a/src/include/from_substrait.hpp
+++ b/src/include/from_substrait.hpp
@@ -9,55 +9,48 @@
 namespace duckdb {
 class SubstraitToDuckDB {
 public:
-  SubstraitToDuckDB(Connection &con_p, string &serialized, bool json = false);
-  //! Transforms Substrait Plan to DuckDB Relation
-  shared_ptr<Relation> TransformPlan();
+	SubstraitToDuckDB(Connection &con_p, string &serialized, bool json = false);
+	//! Transforms Substrait Plan to DuckDB Relation
+	shared_ptr<Relation> TransformPlan();
 
 private:
-  //! Transforms Substrait Plan Root To a DuckDB Relation
-  shared_ptr<Relation> TransformRootOp(const substrait::RelRoot &sop);
-  //! Transform Substrait Operations to DuckDB Relations
-  shared_ptr<Relation> TransformOp(const substrait::Rel &sop);
-  shared_ptr<Relation> TransformJoinOp(const substrait::Rel &sop);
-  shared_ptr<Relation> TransformCrossProductOp(const substrait::Rel &sop);
-  shared_ptr<Relation> TransformFetchOp(const substrait::Rel &sop);
-  shared_ptr<Relation> TransformFilterOp(const substrait::Rel &sop);
-  shared_ptr<Relation> TransformProjectOp(const substrait::Rel &sop);
-  shared_ptr<Relation> TransformAggregateOp(const substrait::Rel &sop);
-  shared_ptr<Relation> TransformReadOp(const substrait::Rel &sop);
-  shared_ptr<Relation> TransformSortOp(const substrait::Rel &sop);
+	//! Transforms Substrait Plan Root To a DuckDB Relation
+	shared_ptr<Relation> TransformRootOp(const substrait::RelRoot &sop);
+	//! Transform Substrait Operations to DuckDB Relations
+	shared_ptr<Relation> TransformOp(const substrait::Rel &sop);
+	shared_ptr<Relation> TransformJoinOp(const substrait::Rel &sop);
+	shared_ptr<Relation> TransformCrossProductOp(const substrait::Rel &sop);
+	shared_ptr<Relation> TransformFetchOp(const substrait::Rel &sop);
+	shared_ptr<Relation> TransformFilterOp(const substrait::Rel &sop);
+	shared_ptr<Relation> TransformProjectOp(const substrait::Rel &sop);
+	shared_ptr<Relation> TransformAggregateOp(const substrait::Rel &sop);
+	shared_ptr<Relation> TransformReadOp(const substrait::Rel &sop);
+	shared_ptr<Relation> TransformSortOp(const substrait::Rel &sop);
 
-  //! Transform Substrait Expressions to DuckDB Expressions
-  unique_ptr<ParsedExpression>
-  TransformExpr(const substrait::Expression &sexpr);
-  unique_ptr<ParsedExpression>
-  TransformLiteralExpr(const substrait::Expression &sexpr);
-  unique_ptr<ParsedExpression>
-  TransformSelectionExpr(const substrait::Expression &sexpr);
-  unique_ptr<ParsedExpression>
-  TransformScalarFunctionExpr(const substrait::Expression &sexpr);
-  unique_ptr<ParsedExpression>
-  TransformIfThenExpr(const substrait::Expression &sexpr);
-  unique_ptr<ParsedExpression>
-  TransformCastExpr(const substrait::Expression &sexpr);
-  unique_ptr<ParsedExpression>
-  TransformInExpr(const substrait::Expression &sexpr);
+	//! Transform Substrait Expressions to DuckDB Expressions
+	unique_ptr<ParsedExpression> TransformExpr(const substrait::Expression &sexpr);
+	unique_ptr<ParsedExpression> TransformLiteralExpr(const substrait::Expression &sexpr);
+	unique_ptr<ParsedExpression> TransformSelectionExpr(const substrait::Expression &sexpr);
+	unique_ptr<ParsedExpression> TransformScalarFunctionExpr(const substrait::Expression &sexpr);
+	unique_ptr<ParsedExpression> TransformIfThenExpr(const substrait::Expression &sexpr);
+	unique_ptr<ParsedExpression> TransformCastExpr(const substrait::Expression &sexpr);
+	unique_ptr<ParsedExpression> TransformInExpr(const substrait::Expression &sexpr);
 
-  std::string &RemapFunctionName(std::string &function_name);
-  LogicalType SubstraitToDuckType(const ::substrait::Type &s_type);
-  //! Looks up for aggregation function in functions_map
-  string FindFunction(uint64_t id);
+	std::string &RemapFunctionName(std::string &function_name);
+	LogicalType SubstraitToDuckType(const ::substrait::Type &s_type);
+	//! Looks up for aggregation function in functions_map
+	string FindFunction(uint64_t id);
 
-  //! Transform Substrait Sort Order to DuckDB Order
-  OrderByNode TransformOrder(const substrait::SortField &sordf);
-  //! DuckDB Connection
-  Connection &con;
-  //! Substrait Plan
-  substrait::Plan plan;
-  //! Variable used to register functions
-  unordered_map<uint64_t, string> functions_map;
-  //! Remapped functions with differing names to the correct DuckDB functions
-  //! names
-  static const unordered_map<std::string, std::string> function_names_remap;
+	//! Transform Substrait Sort Order to DuckDB Order
+	OrderByNode TransformOrder(const substrait::SortField &sordf);
+	//! DuckDB Connection
+	Connection &con;
+	//! Substrait Plan
+	substrait::Plan plan;
+	//! Variable used to register functions
+	unordered_map<uint64_t, string> functions_map;
+	//! Remapped functions with differing names to the correct DuckDB functions
+	//! names
+	static const unordered_map<std::string, std::string> function_names_remap;
 };
 } // namespace duckdb

--- a/src/include/substrait_extension.hpp
+++ b/src/include/substrait_extension.hpp
@@ -14,8 +14,8 @@ namespace duckdb {
 
 class SubstraitExtension : public Extension {
 public:
-  void Load(DuckDB &db) override;
-  std::string Name() override;
+	void Load(DuckDB &db) override;
+	std::string Name() override;
 };
 
 } // namespace duckdb

--- a/src/include/to_substrait.hpp
+++ b/src/include/to_substrait.hpp
@@ -15,162 +15,130 @@
 namespace duckdb {
 class DuckDBToSubstrait {
 public:
-  explicit DuckDBToSubstrait(ClientContext &context,
-                             duckdb::LogicalOperator &dop)
-      : context(context) {
-    TransformPlan(dop);
-  };
+	explicit DuckDBToSubstrait(ClientContext &context, duckdb::LogicalOperator &dop) : context(context) {
+		TransformPlan(dop);
+	};
 
-  ~DuckDBToSubstrait() { plan.Clear(); }
-  //! Serializes the substrait plan to a string
-  string SerializeToString();
-  string SerializeToJson();
+	~DuckDBToSubstrait() {
+		plan.Clear();
+	}
+	//! Serializes the substrait plan to a string
+	string SerializeToString();
+	string SerializeToJson();
 
 private:
-  //! Transform DuckDB Plan to Substrait Plan
-  void TransformPlan(duckdb::LogicalOperator &dop);
-  //! Registers a function
-  uint64_t RegisterFunction(const std::string &name);
-  //! Creates a reference to a table column
-  void CreateFieldRef(substrait::Expression *expr, uint64_t col_idx);
+	//! Transform DuckDB Plan to Substrait Plan
+	void TransformPlan(duckdb::LogicalOperator &dop);
+	//! Registers a function
+	uint64_t RegisterFunction(const std::string &name);
+	//! Creates a reference to a table column
+	void CreateFieldRef(substrait::Expression *expr, uint64_t col_idx);
 
-  //! Transforms Relation Root
-  substrait::RelRoot *TransformRootOp(LogicalOperator &dop);
+	//! Transforms Relation Root
+	substrait::RelRoot *TransformRootOp(LogicalOperator &dop);
 
-  //! Methods to Transform Logical Operators to Substrait Relations
-  substrait::Rel *TransformOp(duckdb::LogicalOperator &dop);
-  substrait::Rel *TransformFilter(duckdb::LogicalOperator &dop);
-  substrait::Rel *TransformProjection(duckdb::LogicalOperator &dop);
-  substrait::Rel *TransformTopN(duckdb::LogicalOperator &dop);
-  substrait::Rel *TransformLimit(duckdb::LogicalOperator &dop);
-  substrait::Rel *TransformOrderBy(duckdb::LogicalOperator &dop);
-  substrait::Rel *TransformComparisonJoin(duckdb::LogicalOperator &dop);
-  substrait::Rel *TransformAggregateGroup(duckdb::LogicalOperator &dop);
-  substrait::Rel *TransformGet(duckdb::LogicalOperator &dop);
-  substrait::Rel *TransformCrossProduct(duckdb::LogicalOperator &dop);
+	//! Methods to Transform Logical Operators to Substrait Relations
+	substrait::Rel *TransformOp(duckdb::LogicalOperator &dop);
+	substrait::Rel *TransformFilter(duckdb::LogicalOperator &dop);
+	substrait::Rel *TransformProjection(duckdb::LogicalOperator &dop);
+	substrait::Rel *TransformTopN(duckdb::LogicalOperator &dop);
+	substrait::Rel *TransformLimit(duckdb::LogicalOperator &dop);
+	substrait::Rel *TransformOrderBy(duckdb::LogicalOperator &dop);
+	substrait::Rel *TransformComparisonJoin(duckdb::LogicalOperator &dop);
+	substrait::Rel *TransformAggregateGroup(duckdb::LogicalOperator &dop);
+	substrait::Rel *TransformGet(duckdb::LogicalOperator &dop);
+	substrait::Rel *TransformCrossProduct(duckdb::LogicalOperator &dop);
 
-  //! Methods to transform different LogicalGet Types (e.g., Table, Parquet)
-  //! To Substrait;
-  void TransformTableScanToSubstrait(LogicalGet &dget,
-                                     substrait::ReadRel *sget);
-  void TransformParquetScanToSubstrait(LogicalGet &dget,
-                                       substrait::ReadRel *sget,
-                                       BindInfo &bind_info,
-                                       FunctionData &bind_data);
+	//! Methods to transform different LogicalGet Types (e.g., Table, Parquet)
+	//! To Substrait;
+	void TransformTableScanToSubstrait(LogicalGet &dget, substrait::ReadRel *sget);
+	void TransformParquetScanToSubstrait(LogicalGet &dget, substrait::ReadRel *sget, BindInfo &bind_info,
+	                                     FunctionData &bind_data);
 
-  //! Methods to transform DuckDBConstants to Substrait Expressions
-  void TransformConstant(duckdb::Value &dval, substrait::Expression &sexpr);
-  void TransformInteger(duckdb::Value &dval, substrait::Expression &sexpr);
-  void TransformDouble(Value &dval, substrait::Expression &sexpr);
-  void TransformBigInt(duckdb::Value &dval, substrait::Expression &sexpr);
-  void TransformDate(duckdb::Value &dval, substrait::Expression &sexpr);
-  void TransformVarchar(duckdb::Value &dval, substrait::Expression &sexpr);
-  void TransformBoolean(duckdb::Value &dval, substrait::Expression &sexpr);
-  void TransformDecimal(duckdb::Value &dval, substrait::Expression &sexpr);
-  void TransformHugeInt(Value &dval, substrait::Expression &sexpr);
-  void TransformSmallInt(duckdb::Value &dval, substrait::Expression &sexpr);
-  void TransformFloat(Value &dval, substrait::Expression &sexpr);
-  void TransformTime(Value &dval, substrait::Expression &sexpr);
-  void TransformInterval(Value &dval, substrait::Expression &sexpr);
-  void TransformTimestamp(Value &dval, substrait::Expression &sexpr);
-  void TransformEnum(duckdb::Value &dval, substrait::Expression &sexpr);
+	//! Methods to transform DuckDBConstants to Substrait Expressions
+	void TransformConstant(duckdb::Value &dval, substrait::Expression &sexpr);
+	void TransformInteger(duckdb::Value &dval, substrait::Expression &sexpr);
+	void TransformDouble(Value &dval, substrait::Expression &sexpr);
+	void TransformBigInt(duckdb::Value &dval, substrait::Expression &sexpr);
+	void TransformDate(duckdb::Value &dval, substrait::Expression &sexpr);
+	void TransformVarchar(duckdb::Value &dval, substrait::Expression &sexpr);
+	void TransformBoolean(duckdb::Value &dval, substrait::Expression &sexpr);
+	void TransformDecimal(duckdb::Value &dval, substrait::Expression &sexpr);
+	void TransformHugeInt(Value &dval, substrait::Expression &sexpr);
+	void TransformSmallInt(duckdb::Value &dval, substrait::Expression &sexpr);
+	void TransformFloat(Value &dval, substrait::Expression &sexpr);
+	void TransformTime(Value &dval, substrait::Expression &sexpr);
+	void TransformInterval(Value &dval, substrait::Expression &sexpr);
+	void TransformTimestamp(Value &dval, substrait::Expression &sexpr);
+	void TransformEnum(duckdb::Value &dval, substrait::Expression &sexpr);
 
-  //! Methods to transform a DuckDB Expression to a Substrait Expression
-  void TransformExpr(duckdb::Expression &dexpr, substrait::Expression &sexpr,
-                     uint64_t col_offset = 0);
-  void TransformBoundRefExpression(duckdb::Expression &dexpr,
-                                   substrait::Expression &sexpr,
-                                   uint64_t col_offset);
-  void TransformCastExpression(duckdb::Expression &dexpr,
-                               substrait::Expression &sexpr,
-                               uint64_t col_offset);
-  void TransformFunctionExpression(duckdb::Expression &dexpr,
-                                   substrait::Expression &sexpr,
-                                   uint64_t col_offset);
-  void TransformConstantExpression(duckdb::Expression &dexpr,
-                                   substrait::Expression &sexpr);
-  void TransformComparisonExpression(duckdb::Expression &dexpr,
-                                     substrait::Expression &sexpr);
-  void TransformConjunctionExpression(duckdb::Expression &dexpr,
-                                      substrait::Expression &sexpr,
-                                      uint64_t col_offset);
-  void TransformNotNullExpression(duckdb::Expression &dexpr,
-                                  substrait::Expression &sexpr,
-                                  uint64_t col_offset);
-  void TransformIsNullExpression(duckdb::Expression &dexpr,
-                                 substrait::Expression &sexpr,
-                                 uint64_t col_offset);
-  void TransformNotExpression(duckdb::Expression &dexpr,
-                              substrait::Expression &sexpr,
-                              uint64_t col_offset);
-  void TransformCaseExpression(duckdb::Expression &dexpr,
-                               substrait::Expression &sexpr);
-  void TransformInExpression(duckdb::Expression &dexpr,
-                             substrait::Expression &sexpr);
+	//! Methods to transform a DuckDB Expression to a Substrait Expression
+	void TransformExpr(duckdb::Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset = 0);
+	void TransformBoundRefExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset);
+	void TransformCastExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset);
+	void TransformFunctionExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset);
+	void TransformConstantExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr);
+	void TransformComparisonExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr);
+	void TransformConjunctionExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset);
+	void TransformNotNullExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset);
+	void TransformIsNullExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset);
+	void TransformNotExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset);
+	void TransformCaseExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr);
+	void TransformInExpression(duckdb::Expression &dexpr, substrait::Expression &sexpr);
 
-  //! Transforms a DuckDB Logical Type into a Substrait Type
-  ::substrait::Type
-  DuckToSubstraitType(const LogicalType &type,
-                      BaseStatistics *column_statistics = nullptr,
-                      bool not_null = false);
+	//! Transforms a DuckDB Logical Type into a Substrait Type
+	::substrait::Type DuckToSubstraitType(const LogicalType &type, BaseStatistics *column_statistics = nullptr,
+	                                      bool not_null = false);
 
-  //! Methods to transform DuckDB Filters to Substrait Expression
-  substrait::Expression *TransformFilter(uint64_t col_idx,
-                                         duckdb::TableFilter &dfilter,
-                                         LogicalType &return_type);
-  substrait::Expression *TransformIsNotNullFilter(uint64_t col_idx,
-                                                  duckdb::TableFilter &dfilter,
-                                                  LogicalType &return_type);
-  substrait::Expression *
-  TransformConjuctionAndFilter(uint64_t col_idx, duckdb::TableFilter &dfilter,
-                               LogicalType &return_type);
-  substrait::Expression *TransformConstantComparisonFilter(
-      uint64_t col_idx, duckdb::TableFilter &dfilter, LogicalType &return_type);
+	//! Methods to transform DuckDB Filters to Substrait Expression
+	substrait::Expression *TransformFilter(uint64_t col_idx, duckdb::TableFilter &dfilter, LogicalType &return_type);
+	substrait::Expression *TransformIsNotNullFilter(uint64_t col_idx, duckdb::TableFilter &dfilter,
+	                                                LogicalType &return_type);
+	substrait::Expression *TransformConjuctionAndFilter(uint64_t col_idx, duckdb::TableFilter &dfilter,
+	                                                    LogicalType &return_type);
+	substrait::Expression *TransformConstantComparisonFilter(uint64_t col_idx, duckdb::TableFilter &dfilter,
+	                                                         LogicalType &return_type);
 
-  //! Transforms DuckDB Join Conditions to Substrait Expression
-  substrait::Expression *TransformJoinCond(duckdb::JoinCondition &dcond,
-                                           uint64_t left_ncol);
-  //! Transforms DuckDB Sort Order to Substrait Sort Order
-  void TransformOrder(duckdb::BoundOrderByNode &dordf,
-                      substrait::SortField &sordf);
+	//! Transforms DuckDB Join Conditions to Substrait Expression
+	substrait::Expression *TransformJoinCond(duckdb::JoinCondition &dcond, uint64_t left_ncol);
+	//! Transforms DuckDB Sort Order to Substrait Sort Order
+	void TransformOrder(duckdb::BoundOrderByNode &dordf, substrait::SortField &sordf);
 
-  void
-  AllocateFunctionArgument(substrait::Expression_ScalarFunction *scalar_fun,
-                           substrait::Expression *value);
-  std::string &RemapFunctionName(std::string &function_name);
+	void AllocateFunctionArgument(substrait::Expression_ScalarFunction *scalar_fun, substrait::Expression *value);
+	std::string &RemapFunctionName(std::string &function_name);
 
-  //! Creates a Conjuction
-  template <typename T, typename FUNC>
-  substrait::Expression *CreateConjunction(T &source, FUNC f) {
-    substrait::Expression *res = nullptr;
-    for (auto &ele : source) {
-      auto child_expression = f(ele);
-      if (!res) {
-        res = child_expression;
-      } else {
-        auto temp_expr = new substrait::Expression();
-        auto scalar_fun = temp_expr->mutable_scalar_function();
-        scalar_fun->set_function_reference(RegisterFunction("and"));
-        LogicalType boolean_type(LogicalTypeId::BOOLEAN);
-        *scalar_fun->mutable_output_type() = DuckToSubstraitType(boolean_type);
-        AllocateFunctionArgument(scalar_fun, res);
-        AllocateFunctionArgument(scalar_fun, child_expression);
-        res = temp_expr;
-      }
-    }
-    return res;
-  }
+	//! Creates a Conjuction
+	template <typename T, typename FUNC>
+	substrait::Expression *CreateConjunction(T &source, FUNC f) {
+		substrait::Expression *res = nullptr;
+		for (auto &ele : source) {
+			auto child_expression = f(ele);
+			if (!res) {
+				res = child_expression;
+			} else {
+				auto temp_expr = new substrait::Expression();
+				auto scalar_fun = temp_expr->mutable_scalar_function();
+				scalar_fun->set_function_reference(RegisterFunction("and"));
+				LogicalType boolean_type(LogicalTypeId::BOOLEAN);
+				*scalar_fun->mutable_output_type() = DuckToSubstraitType(boolean_type);
+				AllocateFunctionArgument(scalar_fun, res);
+				AllocateFunctionArgument(scalar_fun, child_expression);
+				res = temp_expr;
+			}
+		}
+		return res;
+	}
 
-  //! Variables used to register functions
-  std::unordered_map<std::string, uint64_t> functions_map;
-  //! Remapped DuckDB functions names to Substrait compatible function names
-  static const unordered_map<std::string, std::string> function_names_remap;
-  uint64_t last_function_id = 1;
+	//! Variables used to register functions
+	std::unordered_map<std::string, uint64_t> functions_map;
+	//! Remapped DuckDB functions names to Substrait compatible function names
+	static const unordered_map<std::string, std::string> function_names_remap;
+	uint64_t last_function_id = 1;
 
-  //! The substrait Plan
-  substrait::Plan plan;
-  ClientContext &context;
+	//! The substrait Plan
+	substrait::Plan plan;
+	ClientContext &context;
 
-  uint64_t max_string_length = 1;
+	uint64_t max_string_length = 1;
 };
 } // namespace duckdb

--- a/src/substrait_extension.cpp
+++ b/src/substrait_extension.cpp
@@ -15,207 +15,209 @@
 namespace duckdb {
 
 struct ToSubstraitFunctionData : public TableFunctionData {
-  ToSubstraitFunctionData() {}
-  string query;
-  bool enable_optimizer = true;
-  bool finished = false;
+	ToSubstraitFunctionData() {
+	}
+	string query;
+	bool enable_optimizer = true;
+	bool finished = false;
 };
 
-static unique_ptr<FunctionData>
-ToSubstraitBind(ClientContext &context, TableFunctionBindInput &input,
-                vector<LogicalType> &return_types, vector<string> &names) {
-  auto result = make_unique<ToSubstraitFunctionData>();
-  result->query = input.inputs[0].ToString();
-  if (input.named_parameters.size() == 1) {
-    auto loption = StringUtil::Lower(input.named_parameters.begin()->first);
-    if (loption == "enable_optimizer") {
-      result->enable_optimizer =
-          BooleanValue::Get(input.named_parameters.begin()->second);
-    }
-  }
-  return_types.emplace_back(LogicalType::BLOB);
-  names.emplace_back("Plan Blob");
-  return move(result);
+static unique_ptr<FunctionData> ToSubstraitBind(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_unique<ToSubstraitFunctionData>();
+	result->query = input.inputs[0].ToString();
+	if (input.named_parameters.size() == 1) {
+		auto loption = StringUtil::Lower(input.named_parameters.begin()->first);
+		if (loption == "enable_optimizer") {
+			result->enable_optimizer = BooleanValue::Get(input.named_parameters.begin()->second);
+		}
+	}
+	return_types.emplace_back(LogicalType::BLOB);
+	names.emplace_back("Plan Blob");
+	return move(result);
 }
 
-static unique_ptr<FunctionData> ToJsonBind(ClientContext &context,
-                                           TableFunctionBindInput &input,
-                                           vector<LogicalType> &return_types,
-                                           vector<string> &names) {
-  auto result = make_unique<ToSubstraitFunctionData>();
-  result->query = input.inputs[0].ToString();
-  if (input.named_parameters.size() == 1) {
-    auto loption = StringUtil::Lower(input.named_parameters.begin()->first);
-    if (loption == "enable_optimizer") {
-      result->enable_optimizer =
-          BooleanValue::Get(input.named_parameters.begin()->second);
-    }
-  }
-  return_types.emplace_back(LogicalType::VARCHAR);
-  names.emplace_back("Json");
-  return move(result);
+static unique_ptr<FunctionData> ToJsonBind(ClientContext &context, TableFunctionBindInput &input,
+                                           vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_unique<ToSubstraitFunctionData>();
+	result->query = input.inputs[0].ToString();
+	if (input.named_parameters.size() == 1) {
+		auto loption = StringUtil::Lower(input.named_parameters.begin()->first);
+		if (loption == "enable_optimizer") {
+			result->enable_optimizer = BooleanValue::Get(input.named_parameters.begin()->second);
+		}
+	}
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("Json");
+	return move(result);
 }
 
-shared_ptr<Relation> SubstraitPlanToDuckDBRel(Connection &conn,
-                                              string &serialized,
-                                              bool json = false) {
-  SubstraitToDuckDB transformer_s2d(conn, serialized, json);
-  return transformer_s2d.TransformPlan();
+shared_ptr<Relation> SubstraitPlanToDuckDBRel(Connection &conn, string &serialized, bool json = false) {
+	SubstraitToDuckDB transformer_s2d(conn, serialized, json);
+	return transformer_s2d.TransformPlan();
 }
 
-static void ToSubFunction(ClientContext &context, TableFunctionInput &data_p,
-                          DataChunk &output) {
-  auto &data = (ToSubstraitFunctionData &)*data_p.bind_data;
-  if (data.finished) {
-    return;
-  }
-  output.SetCardinality(1);
-  auto new_conn = Connection(*context.db);
-  // We might want to disable the optimizer of our new connection
-  new_conn.context->config.enable_optimizer = data.enable_optimizer;
-  new_conn.context->config.use_replacement_scans = false;
-  auto query_plan = new_conn.context->ExtractPlan(data.query);
-  DuckDBToSubstrait transformer_d2s(context, *query_plan);
-  auto serialized = transformer_d2s.SerializeToString();
+static void ToSubFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (ToSubstraitFunctionData &)*data_p.bind_data;
+	if (data.finished) {
+		return;
+	}
+	output.SetCardinality(1);
+	auto new_conn = Connection(*context.db);
+	// We might want to disable the optimizer of our new connection
+	new_conn.context->config.enable_optimizer = data.enable_optimizer;
+	new_conn.context->config.use_replacement_scans = false;
+	auto query_plan = new_conn.context->ExtractPlan(data.query);
+	DuckDBToSubstrait transformer_d2s(context, *query_plan);
+	auto serialized = transformer_d2s.SerializeToString();
 
-  output.SetValue(0, 0, Value::BLOB_RAW(serialized));
-  data.finished = true;
-  if (context.config.query_verification_enabled) {
-    // We round-trip the generated blob and verify if the result is the same
-    auto actual_result = new_conn.Query(data.query);
-    auto sub_relation = SubstraitPlanToDuckDBRel(new_conn, serialized);
-    auto substrait_result = sub_relation->Execute();
-    substrait_result->names = actual_result->names;
-    if (!actual_result->Equals(*substrait_result)) {
-      query_plan->Print();
-      sub_relation->Print();
-      throw InternalException(
-          "The query result of DuckDB's query plan does not match Substrait");
-    }
-  }
+	output.SetValue(0, 0, Value::BLOB_RAW(serialized));
+	data.finished = true;
+	if (context.config.query_verification_enabled) {
+		// We round-trip the generated blob and verify if the result is the same
+		auto actual_result = new_conn.Query(data.query);
+		auto sub_relation = SubstraitPlanToDuckDBRel(new_conn, serialized);
+		auto substrait_result = sub_relation->Execute();
+		substrait_result->names = actual_result->names;
+		if (!actual_result->Equals(*substrait_result)) {
+			query_plan->Print();
+			sub_relation->Print();
+			throw InternalException("The query result of DuckDB's query plan does not match Substrait");
+		}
+	}
 }
 
-static void ToJsonFunction(ClientContext &context, TableFunctionInput &data_p,
-                           DataChunk &output) {
-  auto &data = (ToSubstraitFunctionData &)*data_p.bind_data;
-  if (data.finished) {
-    return;
-  }
-  output.SetCardinality(1);
-  auto new_conn = Connection(*context.db);
-  // We might want to disable the optimizer of our new connection
-  new_conn.context->config.enable_optimizer = data.enable_optimizer;
-  new_conn.context->config.use_replacement_scans = false;
-  auto query_plan = new_conn.context->ExtractPlan(data.query);
-  DuckDBToSubstrait transformer_d2s(context, *query_plan);
-  auto serialized = transformer_d2s.SerializeToJson();
+static void ToJsonFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (ToSubstraitFunctionData &)*data_p.bind_data;
+	if (data.finished) {
+		return;
+	}
+	output.SetCardinality(1);
+	auto new_conn = Connection(*context.db);
+	// We might want to disable the optimizer of our new connection
+	new_conn.context->config.enable_optimizer = data.enable_optimizer;
+	new_conn.context->config.use_replacement_scans = false;
+	auto query_plan = new_conn.context->ExtractPlan(data.query);
+	DuckDBToSubstrait transformer_d2s(context, *query_plan);
+	auto serialized = transformer_d2s.SerializeToJson();
 
-  output.SetValue(0, 0, serialized);
-  data.finished = true;
+	output.SetValue(0, 0, serialized);
+	data.finished = true;
 }
 
 struct FromSubstraitFunctionData : public TableFunctionData {
-  FromSubstraitFunctionData() = default;
-  shared_ptr<Relation> plan;
-  unique_ptr<QueryResult> res;
-  unique_ptr<Connection> conn;
+	FromSubstraitFunctionData() = default;
+	shared_ptr<Relation> plan;
+	unique_ptr<QueryResult> res;
+	unique_ptr<Connection> conn;
 };
 
-static unique_ptr<FunctionData> SubstraitBind(ClientContext &context,
-                                              TableFunctionBindInput &input,
-                                              vector<LogicalType> &return_types,
-                                              vector<string> &names,
-                                              bool is_json) {
-  auto result = make_unique<FromSubstraitFunctionData>();
-  result->conn = make_unique<Connection>(*context.db);
-  string serialized = input.inputs[0].GetValueUnsafe<string>();
-  result->plan = SubstraitPlanToDuckDBRel(*result->conn, serialized, is_json);
-  for (auto &column : result->plan->Columns()) {
-    return_types.emplace_back(column.Type());
-    names.emplace_back(column.Name());
-  }
-  return move(result);
+static unique_ptr<FunctionData> SubstraitBind(ClientContext &context, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types, vector<string> &names, bool is_json) {
+	auto result = make_unique<FromSubstraitFunctionData>();
+	result->conn = make_unique<Connection>(*context.db);
+	string serialized = input.inputs[0].GetValueUnsafe<string>();
+	result->plan = SubstraitPlanToDuckDBRel(*result->conn, serialized, is_json);
+	for (auto &column : result->plan->Columns()) {
+		return_types.emplace_back(column.Type());
+		names.emplace_back(column.Name());
+	}
+	return move(result);
 }
 
-static unique_ptr<FunctionData>
-FromSubstraitBind(ClientContext &context, TableFunctionBindInput &input,
-                  vector<LogicalType> &return_types, vector<string> &names) {
-  return SubstraitBind(context, input, return_types, names, false);
+static unique_ptr<FunctionData> FromSubstraitBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	return SubstraitBind(context, input, return_types, names, false);
 }
 
-static unique_ptr<FunctionData>
-FromSubstraitBindJSON(ClientContext &context, TableFunctionBindInput &input,
-                      vector<LogicalType> &return_types,
-                      vector<string> &names) {
-  return SubstraitBind(context, input, return_types, names, true);
+static unique_ptr<FunctionData> FromSubstraitBindJSON(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	return SubstraitBind(context, input, return_types, names, true);
 }
 
-static void FromSubFunction(ClientContext &context, TableFunctionInput &data_p,
-                            DataChunk &output) {
-  auto &data = (FromSubstraitFunctionData &)*data_p.bind_data;
-  if (!data.res) {
-    data.res = data.plan->Execute();
-  }
-  auto result_chunk = data.res->Fetch();
-  if (!result_chunk) {
-    return;
-  }
-  output.Move(*result_chunk);
+static void FromSubFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (FromSubstraitFunctionData &)*data_p.bind_data;
+	if (!data.res) {
+		data.res = data.plan->Execute();
+	}
+	auto result_chunk = data.res->Fetch();
+	if (!result_chunk) {
+		return;
+	}
+	output.Move(*result_chunk);
+}
+
+void InitializeGetSubstrait(Connection &con) {
+	auto &catalog = Catalog::GetSystemCatalog(*con.context);
+
+	// create the get_substrait table function that allows us to get a substrait
+	// binary from a valid SQL Query
+	TableFunction to_sub_func("get_substrait", {LogicalType::VARCHAR}, ToSubFunction, ToSubstraitBind);
+	to_sub_func.named_parameters["enable_optimizer"] = LogicalType::BOOLEAN;
+	CreateTableFunctionInfo to_sub_info(to_sub_func);
+	catalog.CreateTableFunction(*con.context, &to_sub_info);
+}
+
+void InitializeGetSubstraitJSON(Connection &con) {
+	auto &catalog = Catalog::GetSystemCatalog(*con.context);
+
+	// create the get_substrait table function that allows us to get a substrait
+	// JSON from a valid SQL Query
+	TableFunction get_substrait_json("get_substrait_json", {LogicalType::VARCHAR}, ToJsonFunction, ToJsonBind);
+
+	get_substrait_json.named_parameters["enable_optimizer"] = LogicalType::BOOLEAN;
+	CreateTableFunctionInfo get_substrait_json_info(get_substrait_json);
+	catalog.CreateTableFunction(*con.context, &get_substrait_json_info);
+}
+
+void InitializeFromSubstrait(Connection &con) {
+	auto &catalog = Catalog::GetSystemCatalog(*con.context);
+
+	// create the from_substrait table function that allows us to get a query
+	// result from a substrait plan
+	TableFunction from_sub_func("from_substrait", {LogicalType::BLOB}, FromSubFunction, FromSubstraitBind);
+	CreateTableFunctionInfo from_sub_info(from_sub_func);
+	catalog.CreateTableFunction(*con.context, &from_sub_info);
+}
+
+void InitializeFromSubstraitJSON(Connection &con) {
+	auto &catalog = Catalog::GetSystemCatalog(*con.context);
+
+	// create the from_substrait table function that allows us to get a query
+	// result from a substrait plan
+	TableFunction from_sub_func_json("from_substrait_json", {LogicalType::VARCHAR}, FromSubFunction,
+	                                 FromSubstraitBindJSON);
+	CreateTableFunctionInfo from_sub_info_json(from_sub_func_json);
+	catalog.CreateTableFunction(*con.context, &from_sub_info_json);
 }
 
 void SubstraitExtension::Load(DuckDB &db) {
-  Connection con(db);
-  con.BeginTransaction();
-  auto &catalog = Catalog::GetSystemCatalog(*con.context);
+	Connection con(db);
+	con.BeginTransaction();
 
-  // create the get_substrait table function that allows us to get a substrait
-  // binary from a valid SQL Query
-  TableFunction to_sub_func("get_substrait", {LogicalType::VARCHAR},
-                            ToSubFunction, ToSubstraitBind);
-  to_sub_func.named_parameters["enable_optimizer"] = LogicalType::BOOLEAN;
-  CreateTableFunctionInfo to_sub_info(to_sub_func);
-  catalog.CreateTableFunction(*con.context, &to_sub_info);
+	InitializeGetSubstrait(con);
+	InitializeGetSubstraitJSON(con);
 
-  // create the from_substrait table function that allows us to get a query
-  // result from a substrait plan
-  TableFunction from_sub_func("from_substrait", {LogicalType::BLOB},
-                              FromSubFunction, FromSubstraitBind);
-  CreateTableFunctionInfo from_sub_info(from_sub_func);
-  catalog.CreateTableFunction(*con.context, &from_sub_info);
+	InitializeFromSubstrait(con);
+	InitializeFromSubstraitJSON(con);
 
-  // create the from_substrait table function that allows us to get a query
-  // result from a substrait plan
-  TableFunction from_sub_func_json("from_substrait_json",
-                                   {LogicalType::VARCHAR}, FromSubFunction,
-                                   FromSubstraitBindJSON);
-  CreateTableFunctionInfo from_sub_info_json(from_sub_func_json);
-  catalog.CreateTableFunction(*con.context, &from_sub_info_json);
-
-  // create the get_substrait table function that allows us to get a substrait
-  // JSON from a valid SQL Query
-  TableFunction get_substrait_json("get_substrait_json", {LogicalType::VARCHAR},
-                                   ToJsonFunction, ToJsonBind);
-
-  get_substrait_json.named_parameters["enable_optimizer"] =
-      LogicalType::BOOLEAN;
-  CreateTableFunctionInfo get_substrait_json_info(get_substrait_json);
-  catalog.CreateTableFunction(*con.context, &get_substrait_json_info);
-
-  con.Commit();
+	con.Commit();
 }
 
-std::string SubstraitExtension::Name() { return "substrait"; }
+std::string SubstraitExtension::Name() {
+	return "substrait";
+}
 
 } // namespace duckdb
 
 extern "C" {
 
 DUCKDB_EXTENSION_API void substrait_init(duckdb::DatabaseInstance &db) {
-  duckdb::DuckDB db_wrapper(db);
-  db_wrapper.LoadExtension<duckdb::SubstraitExtension>();
+	duckdb::DuckDB db_wrapper(db);
+	db_wrapper.LoadExtension<duckdb::SubstraitExtension>();
 }
 
 DUCKDB_EXTENSION_API const char *substrait_version() {
-  return duckdb::DuckDB::LibraryVersion();
+	return duckdb::DuckDB::LibraryVersion();
 }
 }

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -19,1235 +19,1157 @@
 #include "duckdb/execution/index/art/art_key.hpp"
 
 namespace duckdb {
-const std::unordered_map<std::string, std::string>
-    DuckDBToSubstrait::function_names_remap = {
-        {"mod", "modulus"},        {"stddev", "std_dev"},
-        {"prefix", "starts_with"}, {"suffix", "ends_with"},
-        {"substr", "substring"},   {"length", "char_length"},
-        {"isnan", "is_nan"},       {"isfinite", "is_finite"},
-        {"isinf", "is_infinite"},  {"sum_no_overflow", "sum"},
-        {"count_star", "count"},   {"~~", "like"}};
+const std::unordered_map<std::string, std::string> DuckDBToSubstrait::function_names_remap = {
+    {"mod", "modulus"},       {"stddev", "std_dev"},      {"prefix", "starts_with"}, {"suffix", "ends_with"},
+    {"substr", "substring"},  {"length", "char_length"},  {"isnan", "is_nan"},       {"isfinite", "is_finite"},
+    {"isinf", "is_infinite"}, {"sum_no_overflow", "sum"}, {"count_star", "count"},   {"~~", "like"}};
 
 std::string &DuckDBToSubstrait::RemapFunctionName(std::string &function_name) {
-  auto it = function_names_remap.find(function_name);
-  if (it != function_names_remap.end()) {
-    function_name = it->second;
-  }
-  return function_name;
+	auto it = function_names_remap.find(function_name);
+	if (it != function_names_remap.end()) {
+		function_name = it->second;
+	}
+	return function_name;
 }
 
 string DuckDBToSubstrait::SerializeToString() {
-  string serialized;
-  if (!plan.SerializeToString(&serialized)) {
-    throw InternalException(
-        "It was not possible to serialize the substrait plan");
-  }
-  return serialized;
+	string serialized;
+	if (!plan.SerializeToString(&serialized)) {
+		throw InternalException("It was not possible to serialize the substrait plan");
+	}
+	return serialized;
 }
 
 string DuckDBToSubstrait::SerializeToJson() {
-  string serialized;
-  auto success = google::protobuf::util::MessageToJsonString(plan, &serialized);
-  if (!success.ok()) {
-    throw InternalException(
-        "It was not possible to serialize the substrait plan");
-  }
-  return serialized;
+	string serialized;
+	auto success = google::protobuf::util::MessageToJsonString(plan, &serialized);
+	if (!success.ok()) {
+		throw InternalException("It was not possible to serialize the substrait plan");
+	}
+	return serialized;
 }
 
-void DuckDBToSubstrait::AllocateFunctionArgument(
-    substrait::Expression_ScalarFunction *scalar_fun,
-    substrait::Expression *value) {
-  auto function_argument = new substrait::FunctionArgument();
-  function_argument->set_allocated_value(value);
-  scalar_fun->mutable_arguments()->AddAllocated(function_argument);
+void DuckDBToSubstrait::AllocateFunctionArgument(substrait::Expression_ScalarFunction *scalar_fun,
+                                                 substrait::Expression *value) {
+	auto function_argument = new substrait::FunctionArgument();
+	function_argument->set_allocated_value(value);
+	scalar_fun->mutable_arguments()->AddAllocated(function_argument);
 }
 
 string GetRawValue(hugeint_t value) {
-  std::string str;
-  str.reserve(16);
-  uint8_t *byte = (uint8_t *)&value.lower;
-  for (idx_t i = 0; i < 8; i++) {
-    str.push_back(byte[i]);
-  }
-  byte = (uint8_t *)&value.upper;
-  for (idx_t i = 0; i < 8; i++) {
-    str.push_back(byte[i]);
-  }
+	std::string str;
+	str.reserve(16);
+	uint8_t *byte = (uint8_t *)&value.lower;
+	for (idx_t i = 0; i < 8; i++) {
+		str.push_back(byte[i]);
+	}
+	byte = (uint8_t *)&value.upper;
+	for (idx_t i = 0; i < 8; i++) {
+		str.push_back(byte[i]);
+	}
 
-  return str;
+	return str;
 }
 
-void DuckDBToSubstrait::TransformDecimal(Value &dval,
-                                         substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  auto *allocated_decimal = new ::substrait::Expression_Literal_Decimal();
-  uint8_t scale, width;
-  hugeint_t hugeint_value;
-  Value mock_value;
-  // alright time for some dirty switcharoo
-  switch (dval.type().InternalType()) {
-  case PhysicalType::INT8: {
-    auto internal_value = dval.GetValueUnsafe<int8_t>();
-    mock_value = Value::TINYINT(internal_value);
-    break;
-  }
+void DuckDBToSubstrait::TransformDecimal(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	auto *allocated_decimal = new ::substrait::Expression_Literal_Decimal();
+	uint8_t scale, width;
+	hugeint_t hugeint_value;
+	Value mock_value;
+	// alright time for some dirty switcharoo
+	switch (dval.type().InternalType()) {
+	case PhysicalType::INT8: {
+		auto internal_value = dval.GetValueUnsafe<int8_t>();
+		mock_value = Value::TINYINT(internal_value);
+		break;
+	}
 
-  case PhysicalType::INT16: {
-    auto internal_value = dval.GetValueUnsafe<int16_t>();
-    mock_value = Value::SMALLINT(internal_value);
-    break;
-  }
-  case PhysicalType::INT32: {
-    auto internal_value = dval.GetValueUnsafe<int32_t>();
-    mock_value = Value::INTEGER(internal_value);
-    break;
-  }
-  case PhysicalType::INT64: {
-    auto internal_value = dval.GetValueUnsafe<int64_t>();
-    mock_value = Value::BIGINT(internal_value);
-    break;
-  }
-  case PhysicalType::INT128: {
-    auto internal_value = dval.GetValueUnsafe<hugeint_t>();
-    mock_value = Value::HUGEINT(internal_value);
-    break;
-  }
-  default:
-    throw InternalException("Not accepted internal type for decimal");
-  }
-  hugeint_value = mock_value.GetValue<hugeint_t>();
-  auto raw_value = GetRawValue(hugeint_value);
+	case PhysicalType::INT16: {
+		auto internal_value = dval.GetValueUnsafe<int16_t>();
+		mock_value = Value::SMALLINT(internal_value);
+		break;
+	}
+	case PhysicalType::INT32: {
+		auto internal_value = dval.GetValueUnsafe<int32_t>();
+		mock_value = Value::INTEGER(internal_value);
+		break;
+	}
+	case PhysicalType::INT64: {
+		auto internal_value = dval.GetValueUnsafe<int64_t>();
+		mock_value = Value::BIGINT(internal_value);
+		break;
+	}
+	case PhysicalType::INT128: {
+		auto internal_value = dval.GetValueUnsafe<hugeint_t>();
+		mock_value = Value::HUGEINT(internal_value);
+		break;
+	}
+	default:
+		throw InternalException("Not accepted internal type for decimal");
+	}
+	hugeint_value = mock_value.GetValue<hugeint_t>();
+	auto raw_value = GetRawValue(hugeint_value);
 
-  dval.type().GetDecimalProperties(width, scale);
+	dval.type().GetDecimalProperties(width, scale);
 
-  allocated_decimal->set_scale(scale);
-  allocated_decimal->set_precision(width);
-  auto *decimal_value = new string();
-  *decimal_value = raw_value;
-  allocated_decimal->set_allocated_value(decimal_value);
-  sval.set_allocated_decimal(allocated_decimal);
+	allocated_decimal->set_scale(scale);
+	allocated_decimal->set_precision(width);
+	auto *decimal_value = new string();
+	*decimal_value = raw_value;
+	allocated_decimal->set_allocated_value(decimal_value);
+	sval.set_allocated_decimal(allocated_decimal);
 }
 
-void DuckDBToSubstrait::TransformInteger(Value &dval,
-                                         substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  sval.set_i32(dval.GetValue<int32_t>());
+void DuckDBToSubstrait::TransformInteger(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	sval.set_i32(dval.GetValue<int32_t>());
 }
 
-void DuckDBToSubstrait::TransformSmallInt(Value &dval,
-                                          substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  sval.set_i16(dval.GetValue<int16_t>());
+void DuckDBToSubstrait::TransformSmallInt(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	sval.set_i16(dval.GetValue<int16_t>());
 }
 
-void DuckDBToSubstrait::TransformDouble(Value &dval,
-                                        substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  sval.set_fp64(dval.GetValue<double>());
+void DuckDBToSubstrait::TransformDouble(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	sval.set_fp64(dval.GetValue<double>());
 }
 
-void DuckDBToSubstrait::TransformFloat(Value &dval,
-                                       substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  sval.set_fp32(dval.GetValue<float>());
+void DuckDBToSubstrait::TransformFloat(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	sval.set_fp32(dval.GetValue<float>());
 }
 
-void DuckDBToSubstrait::TransformBigInt(Value &dval,
-                                        substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  sval.set_i64(dval.GetValue<int64_t>());
+void DuckDBToSubstrait::TransformBigInt(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	sval.set_i64(dval.GetValue<int64_t>());
 }
 
-void DuckDBToSubstrait::TransformDate(Value &dval,
-                                      substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  sval.set_date(dval.GetValue<date_t>().days);
+void DuckDBToSubstrait::TransformDate(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	sval.set_date(dval.GetValue<date_t>().days);
 }
 
-void DuckDBToSubstrait::TransformTime(Value &dval,
-                                      substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  sval.set_time(dval.GetValue<dtime_t>().micros);
+void DuckDBToSubstrait::TransformTime(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	sval.set_time(dval.GetValue<dtime_t>().micros);
 }
 
-void DuckDBToSubstrait::TransformTimestamp(Value &dval,
-                                           substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  sval.set_string(dval.ToString());
+void DuckDBToSubstrait::TransformTimestamp(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	sval.set_string(dval.ToString());
 }
 
-void DuckDBToSubstrait::TransformInterval(Value &dval,
-                                          substrait::Expression &sexpr) {
-  // Substrait supports two types of INTERVAL (interval_year and interval_day)
-  // whereas DuckDB INTERVAL combines both in one type. Therefore intervals
-  // containing both months and days or seconds will lose some data
-  // unfortunately. This implementation opts to set the largest interval value.
-  auto &sval = *sexpr.mutable_literal();
-  auto months = dval.GetValue<interval_t>().months;
-  if (months != 0) {
-    auto interval_year =
-        make_unique<substrait::Expression_Literal_IntervalYearToMonth>();
-    interval_year->set_months(months);
-    sval.set_allocated_interval_year_to_month(interval_year.release());
-  } else {
-    auto interval_day =
-        make_unique<substrait::Expression_Literal_IntervalDayToSecond>();
-    interval_day->set_days(dval.GetValue<interval_t>().days);
-    interval_day->set_microseconds(dval.GetValue<interval_t>().micros);
-    sval.set_allocated_interval_day_to_second(interval_day.release());
-  }
+void DuckDBToSubstrait::TransformInterval(Value &dval, substrait::Expression &sexpr) {
+	// Substrait supports two types of INTERVAL (interval_year and interval_day)
+	// whereas DuckDB INTERVAL combines both in one type. Therefore intervals
+	// containing both months and days or seconds will lose some data
+	// unfortunately. This implementation opts to set the largest interval value.
+	auto &sval = *sexpr.mutable_literal();
+	auto months = dval.GetValue<interval_t>().months;
+	if (months != 0) {
+		auto interval_year = make_unique<substrait::Expression_Literal_IntervalYearToMonth>();
+		interval_year->set_months(months);
+		sval.set_allocated_interval_year_to_month(interval_year.release());
+	} else {
+		auto interval_day = make_unique<substrait::Expression_Literal_IntervalDayToSecond>();
+		interval_day->set_days(dval.GetValue<interval_t>().days);
+		interval_day->set_microseconds(dval.GetValue<interval_t>().micros);
+		sval.set_allocated_interval_day_to_second(interval_day.release());
+	}
 }
 
-void DuckDBToSubstrait::TransformVarchar(Value &dval,
-                                         substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  string duck_str = dval.GetValue<string>();
-  sval.set_string(dval.GetValue<string>());
+void DuckDBToSubstrait::TransformVarchar(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	string duck_str = dval.GetValue<string>();
+	sval.set_string(dval.GetValue<string>());
 }
 
-void DuckDBToSubstrait::TransformBoolean(Value &dval,
-                                         substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  sval.set_boolean(dval.GetValue<bool>());
+void DuckDBToSubstrait::TransformBoolean(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	sval.set_boolean(dval.GetValue<bool>());
 }
 
-void DuckDBToSubstrait::TransformHugeInt(Value &dval,
-                                         substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  auto *allocated_decimal = new ::substrait::Expression_Literal_Decimal();
-  auto hugeint = dval.GetValueUnsafe<hugeint_t>();
-  auto raw_value = GetRawValue(hugeint);
-  allocated_decimal->set_scale(0);
-  allocated_decimal->set_precision(38);
+void DuckDBToSubstrait::TransformHugeInt(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	auto *allocated_decimal = new ::substrait::Expression_Literal_Decimal();
+	auto hugeint = dval.GetValueUnsafe<hugeint_t>();
+	auto raw_value = GetRawValue(hugeint);
+	allocated_decimal->set_scale(0);
+	allocated_decimal->set_precision(38);
 
-  auto *decimal_value = new string();
-  *decimal_value = raw_value;
-  allocated_decimal->set_allocated_value(decimal_value);
-  sval.set_allocated_decimal(allocated_decimal);
+	auto *decimal_value = new string();
+	*decimal_value = raw_value;
+	allocated_decimal->set_allocated_value(decimal_value);
+	sval.set_allocated_decimal(allocated_decimal);
 }
 
-void DuckDBToSubstrait::TransformEnum(Value &dval,
-                                      substrait::Expression &sexpr) {
-  auto &sval = *sexpr.mutable_literal();
-  sval.set_string(dval.ToString());
+void DuckDBToSubstrait::TransformEnum(Value &dval, substrait::Expression &sexpr) {
+	auto &sval = *sexpr.mutable_literal();
+	sval.set_string(dval.ToString());
 }
 
-void DuckDBToSubstrait::TransformConstant(Value &dval,
-                                          substrait::Expression &sexpr) {
-  if (dval.IsNull()) {
-    sexpr.mutable_literal()->mutable_null();
-    return;
-  }
-  auto &duckdb_type = dval.type();
-  switch (duckdb_type.id()) {
-  case LogicalTypeId::DECIMAL:
-    TransformDecimal(dval, sexpr);
-    break;
-  case LogicalTypeId::INTEGER:
-    TransformInteger(dval, sexpr);
-    break;
-  case LogicalTypeId::SMALLINT:
-    TransformSmallInt(dval, sexpr);
-    break;
-  case LogicalTypeId::BIGINT:
-    TransformBigInt(dval, sexpr);
-    break;
-  case LogicalTypeId::HUGEINT:
-    TransformHugeInt(dval, sexpr);
-    break;
-  case LogicalTypeId::DATE:
-    TransformDate(dval, sexpr);
-    break;
-  case LogicalTypeId::TIME:
-    TransformTime(dval, sexpr);
-    break;
-  case LogicalTypeId::TIMESTAMP_SEC:
-  case LogicalTypeId::TIMESTAMP_MS:
-  case LogicalTypeId::TIMESTAMP_NS:
-  case LogicalTypeId::TIMESTAMP:
-    TransformTimestamp(dval, sexpr);
-    break;
-  case LogicalTypeId::INTERVAL:
-    TransformInterval(dval, sexpr);
-    break;
-  case LogicalTypeId::VARCHAR:
-  case LogicalTypeId::BLOB:
-    TransformVarchar(dval, sexpr);
-    break;
-  case LogicalTypeId::BOOLEAN:
-    TransformBoolean(dval, sexpr);
-    break;
-  case LogicalTypeId::DOUBLE:
-    TransformDouble(dval, sexpr);
-    break;
-  case LogicalTypeId::FLOAT:
-    TransformFloat(dval, sexpr);
-    break;
-  case LogicalTypeId::ENUM:
-    TransformEnum(dval, sexpr);
-    break;
-  default:
-    throw InternalException("Transform constant of type %s",
-                            duckdb_type.ToString());
-  }
+void DuckDBToSubstrait::TransformConstant(Value &dval, substrait::Expression &sexpr) {
+	if (dval.IsNull()) {
+		sexpr.mutable_literal()->mutable_null();
+		return;
+	}
+	auto &duckdb_type = dval.type();
+	switch (duckdb_type.id()) {
+	case LogicalTypeId::DECIMAL:
+		TransformDecimal(dval, sexpr);
+		break;
+	case LogicalTypeId::INTEGER:
+		TransformInteger(dval, sexpr);
+		break;
+	case LogicalTypeId::SMALLINT:
+		TransformSmallInt(dval, sexpr);
+		break;
+	case LogicalTypeId::BIGINT:
+		TransformBigInt(dval, sexpr);
+		break;
+	case LogicalTypeId::HUGEINT:
+		TransformHugeInt(dval, sexpr);
+		break;
+	case LogicalTypeId::DATE:
+		TransformDate(dval, sexpr);
+		break;
+	case LogicalTypeId::TIME:
+		TransformTime(dval, sexpr);
+		break;
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP:
+		TransformTimestamp(dval, sexpr);
+		break;
+	case LogicalTypeId::INTERVAL:
+		TransformInterval(dval, sexpr);
+		break;
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::BLOB:
+		TransformVarchar(dval, sexpr);
+		break;
+	case LogicalTypeId::BOOLEAN:
+		TransformBoolean(dval, sexpr);
+		break;
+	case LogicalTypeId::DOUBLE:
+		TransformDouble(dval, sexpr);
+		break;
+	case LogicalTypeId::FLOAT:
+		TransformFloat(dval, sexpr);
+		break;
+	case LogicalTypeId::ENUM:
+		TransformEnum(dval, sexpr);
+		break;
+	default:
+		throw InternalException("Transform constant of type %s", duckdb_type.ToString());
+	}
 }
 
-void DuckDBToSubstrait::TransformBoundRefExpression(
-    Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset) {
-  auto &dref = (BoundReferenceExpression &)dexpr;
-  CreateFieldRef(&sexpr, dref.index + col_offset);
+void DuckDBToSubstrait::TransformBoundRefExpression(Expression &dexpr, substrait::Expression &sexpr,
+                                                    uint64_t col_offset) {
+	auto &dref = (BoundReferenceExpression &)dexpr;
+	CreateFieldRef(&sexpr, dref.index + col_offset);
 }
 
-void DuckDBToSubstrait::TransformCastExpression(Expression &dexpr,
-                                                substrait::Expression &sexpr,
-                                                uint64_t col_offset) {
-  auto &dcast = (BoundCastExpression &)dexpr;
-  auto scast = sexpr.mutable_cast();
-  TransformExpr(*dcast.child, *scast->mutable_input(), col_offset);
-  *scast->mutable_type() = DuckToSubstraitType(dcast.return_type);
+void DuckDBToSubstrait::TransformCastExpression(Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset) {
+	auto &dcast = (BoundCastExpression &)dexpr;
+	auto scast = sexpr.mutable_cast();
+	TransformExpr(*dcast.child, *scast->mutable_input(), col_offset);
+	*scast->mutable_type() = DuckToSubstraitType(dcast.return_type);
 }
 
-void DuckDBToSubstrait::TransformFunctionExpression(
-    Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset) {
-  auto &dfun = (BoundFunctionExpression &)dexpr;
-  auto sfun = sexpr.mutable_scalar_function();
+void DuckDBToSubstrait::TransformFunctionExpression(Expression &dexpr, substrait::Expression &sexpr,
+                                                    uint64_t col_offset) {
+	auto &dfun = (BoundFunctionExpression &)dexpr;
+	auto sfun = sexpr.mutable_scalar_function();
 
-  sfun->set_function_reference(
-      RegisterFunction(RemapFunctionName(dfun.function.name)));
+	sfun->set_function_reference(RegisterFunction(RemapFunctionName(dfun.function.name)));
 
-  for (auto &darg : dfun.children) {
-    auto sarg = sfun->add_arguments();
-    TransformExpr(*darg, *sarg->mutable_value(), col_offset);
-  }
-  auto output_type = sfun->mutable_output_type();
-  *output_type = DuckToSubstraitType(dfun.return_type);
+	for (auto &darg : dfun.children) {
+		auto sarg = sfun->add_arguments();
+		TransformExpr(*darg, *sarg->mutable_value(), col_offset);
+	}
+	auto output_type = sfun->mutable_output_type();
+	*output_type = DuckToSubstraitType(dfun.return_type);
 }
 
-void DuckDBToSubstrait::TransformConstantExpression(
-    Expression &dexpr, substrait::Expression &sexpr) {
-  auto &dconst = (BoundConstantExpression &)dexpr;
-  TransformConstant(dconst.value, sexpr);
+void DuckDBToSubstrait::TransformConstantExpression(Expression &dexpr, substrait::Expression &sexpr) {
+	auto &dconst = (BoundConstantExpression &)dexpr;
+	TransformConstant(dconst.value, sexpr);
 }
 
-void DuckDBToSubstrait::TransformComparisonExpression(
-    Expression &dexpr, substrait::Expression &sexpr) {
-  auto &dcomp = (BoundComparisonExpression &)dexpr;
+void DuckDBToSubstrait::TransformComparisonExpression(Expression &dexpr, substrait::Expression &sexpr) {
+	auto &dcomp = (BoundComparisonExpression &)dexpr;
 
-  string fname;
-  switch (dexpr.type) {
-  case ExpressionType::COMPARE_EQUAL:
-    fname = "equal";
-    break;
-  case ExpressionType::COMPARE_LESSTHAN:
-    fname = "lt";
-    break;
-  case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-    fname = "lte";
-    break;
-  case ExpressionType::COMPARE_GREATERTHAN:
-    fname = "gt";
-    break;
-  case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-    fname = "gte";
-    break;
-  case ExpressionType::COMPARE_NOTEQUAL:
-    fname = "not_equal";
-    break;
-  case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
-    fname = "is_not_distinct_from";
-    break;
-  default:
-    throw InternalException(ExpressionTypeToString(dexpr.type));
-  }
+	string fname;
+	switch (dexpr.type) {
+	case ExpressionType::COMPARE_EQUAL:
+		fname = "equal";
+		break;
+	case ExpressionType::COMPARE_LESSTHAN:
+		fname = "lt";
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		fname = "lte";
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		fname = "gt";
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		fname = "gte";
+		break;
+	case ExpressionType::COMPARE_NOTEQUAL:
+		fname = "not_equal";
+		break;
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		fname = "is_not_distinct_from";
+		break;
+	default:
+		throw InternalException(ExpressionTypeToString(dexpr.type));
+	}
 
-  auto scalar_fun = sexpr.mutable_scalar_function();
-  scalar_fun->set_function_reference(RegisterFunction(fname));
-  auto sarg = scalar_fun->add_arguments();
-  TransformExpr(*dcomp.left, *sarg->mutable_value(), 0);
-  sarg = scalar_fun->add_arguments();
-  TransformExpr(*dcomp.right, *sarg->mutable_value(), 0);
-  *scalar_fun->mutable_output_type() = DuckToSubstraitType(dcomp.return_type);
+	auto scalar_fun = sexpr.mutable_scalar_function();
+	scalar_fun->set_function_reference(RegisterFunction(fname));
+	auto sarg = scalar_fun->add_arguments();
+	TransformExpr(*dcomp.left, *sarg->mutable_value(), 0);
+	sarg = scalar_fun->add_arguments();
+	TransformExpr(*dcomp.right, *sarg->mutable_value(), 0);
+	*scalar_fun->mutable_output_type() = DuckToSubstraitType(dcomp.return_type);
 }
 
-void DuckDBToSubstrait::TransformConjunctionExpression(
-    Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset) {
-  auto &dconj = (BoundConjunctionExpression &)dexpr;
-  string fname;
-  switch (dexpr.type) {
-  case ExpressionType::CONJUNCTION_AND:
-    fname = "and";
-    break;
-  case ExpressionType::CONJUNCTION_OR:
-    fname = "or";
-    break;
-  default:
-    throw InternalException(ExpressionTypeToString(dexpr.type));
-  }
+void DuckDBToSubstrait::TransformConjunctionExpression(Expression &dexpr, substrait::Expression &sexpr,
+                                                       uint64_t col_offset) {
+	auto &dconj = (BoundConjunctionExpression &)dexpr;
+	string fname;
+	switch (dexpr.type) {
+	case ExpressionType::CONJUNCTION_AND:
+		fname = "and";
+		break;
+	case ExpressionType::CONJUNCTION_OR:
+		fname = "or";
+		break;
+	default:
+		throw InternalException(ExpressionTypeToString(dexpr.type));
+	}
 
-  auto scalar_fun = sexpr.mutable_scalar_function();
-  scalar_fun->set_function_reference(RegisterFunction(fname));
-  for (auto &child : dconj.children) {
-    auto s_arg = scalar_fun->add_arguments();
-    TransformExpr(*child, *s_arg->mutable_value(), col_offset);
-  }
-  *scalar_fun->mutable_output_type() = DuckToSubstraitType(dconj.return_type);
+	auto scalar_fun = sexpr.mutable_scalar_function();
+	scalar_fun->set_function_reference(RegisterFunction(fname));
+	for (auto &child : dconj.children) {
+		auto s_arg = scalar_fun->add_arguments();
+		TransformExpr(*child, *s_arg->mutable_value(), col_offset);
+	}
+	*scalar_fun->mutable_output_type() = DuckToSubstraitType(dconj.return_type);
 }
 
-void DuckDBToSubstrait::TransformNotNullExpression(Expression &dexpr,
-                                                   substrait::Expression &sexpr,
+void DuckDBToSubstrait::TransformNotNullExpression(Expression &dexpr, substrait::Expression &sexpr,
                                                    uint64_t col_offset) {
-  auto &dop = (BoundOperatorExpression &)dexpr;
-  auto scalar_fun = sexpr.mutable_scalar_function();
-  scalar_fun->set_function_reference(RegisterFunction("is_not_null"));
-  auto s_arg = scalar_fun->add_arguments();
-  TransformExpr(*dop.children[0], *s_arg->mutable_value(), col_offset);
-  *scalar_fun->mutable_output_type() = DuckToSubstraitType(dop.return_type);
+	auto &dop = (BoundOperatorExpression &)dexpr;
+	auto scalar_fun = sexpr.mutable_scalar_function();
+	scalar_fun->set_function_reference(RegisterFunction("is_not_null"));
+	auto s_arg = scalar_fun->add_arguments();
+	TransformExpr(*dop.children[0], *s_arg->mutable_value(), col_offset);
+	*scalar_fun->mutable_output_type() = DuckToSubstraitType(dop.return_type);
 }
 
-void DuckDBToSubstrait::TransformCaseExpression(Expression &dexpr,
-                                                substrait::Expression &sexpr) {
-  auto &dcase = (BoundCaseExpression &)dexpr;
-  auto scase = sexpr.mutable_if_then();
-  for (auto &dcheck : dcase.case_checks) {
-    auto sif = scase->mutable_ifs()->Add();
-    TransformExpr(*dcheck.when_expr, *sif->mutable_if_());
-    auto then_expr = new substrait::Expression();
-    TransformExpr(*dcheck.then_expr, *then_expr);
-    // Push a Cast
-    auto then = sif->mutable_then();
-    auto scast = new substrait::Expression_Cast();
-    *scast->mutable_type() = DuckToSubstraitType(dcase.return_type);
-    scast->set_allocated_input(then_expr);
-    then->set_allocated_cast(scast);
-  }
-  auto else_expr = new substrait::Expression();
-  TransformExpr(*dcase.else_expr, *else_expr);
-  // Push a Cast
-  auto mutable_else = scase->mutable_else_();
-  auto scast = new substrait::Expression_Cast();
-  *scast->mutable_type() = DuckToSubstraitType(dcase.return_type);
-  scast->set_allocated_input(else_expr);
-  else_expr = (substrait::Expression *)scast;
-  mutable_else->set_allocated_cast(scast);
+void DuckDBToSubstrait::TransformCaseExpression(Expression &dexpr, substrait::Expression &sexpr) {
+	auto &dcase = (BoundCaseExpression &)dexpr;
+	auto scase = sexpr.mutable_if_then();
+	for (auto &dcheck : dcase.case_checks) {
+		auto sif = scase->mutable_ifs()->Add();
+		TransformExpr(*dcheck.when_expr, *sif->mutable_if_());
+		auto then_expr = new substrait::Expression();
+		TransformExpr(*dcheck.then_expr, *then_expr);
+		// Push a Cast
+		auto then = sif->mutable_then();
+		auto scast = new substrait::Expression_Cast();
+		*scast->mutable_type() = DuckToSubstraitType(dcase.return_type);
+		scast->set_allocated_input(then_expr);
+		then->set_allocated_cast(scast);
+	}
+	auto else_expr = new substrait::Expression();
+	TransformExpr(*dcase.else_expr, *else_expr);
+	// Push a Cast
+	auto mutable_else = scase->mutable_else_();
+	auto scast = new substrait::Expression_Cast();
+	*scast->mutable_type() = DuckToSubstraitType(dcase.return_type);
+	scast->set_allocated_input(else_expr);
+	else_expr = (substrait::Expression *)scast;
+	mutable_else->set_allocated_cast(scast);
 }
 
-void DuckDBToSubstrait::TransformInExpression(Expression &dexpr,
-                                              substrait::Expression &sexpr) {
-  auto &duck_in_op = (BoundOperatorExpression &)dexpr;
-  auto subs_in_op = sexpr.mutable_singular_or_list();
+void DuckDBToSubstrait::TransformInExpression(Expression &dexpr, substrait::Expression &sexpr) {
+	auto &duck_in_op = (BoundOperatorExpression &)dexpr;
+	auto subs_in_op = sexpr.mutable_singular_or_list();
 
-  // Get the expression
-  TransformExpr(*duck_in_op.children[0], *subs_in_op->mutable_value());
+	// Get the expression
+	TransformExpr(*duck_in_op.children[0], *subs_in_op->mutable_value());
 
-  // Get the values
-  for (idx_t i = 1; i < duck_in_op.children.size(); i++) {
-    subs_in_op->add_options();
-    TransformExpr(*duck_in_op.children[i], *subs_in_op->mutable_options(i - 1));
-  }
+	// Get the values
+	for (idx_t i = 1; i < duck_in_op.children.size(); i++) {
+		subs_in_op->add_options();
+		TransformExpr(*duck_in_op.children[i], *subs_in_op->mutable_options(i - 1));
+	}
 }
 
-void DuckDBToSubstrait::TransformIsNullExpression(Expression &dexpr,
-                                                  substrait::Expression &sexpr,
+void DuckDBToSubstrait::TransformIsNullExpression(Expression &dexpr, substrait::Expression &sexpr,
                                                   uint64_t col_offset) {
-  auto &dop = (BoundOperatorExpression &)dexpr;
-  auto scalar_fun = sexpr.mutable_scalar_function();
-  scalar_fun->set_function_reference(RegisterFunction("is_null"));
-  auto s_arg = scalar_fun->add_arguments();
-  TransformExpr(*dop.children[0], *s_arg->mutable_value(), col_offset);
-  *scalar_fun->mutable_output_type() = DuckToSubstraitType(dop.return_type);
+	auto &dop = (BoundOperatorExpression &)dexpr;
+	auto scalar_fun = sexpr.mutable_scalar_function();
+	scalar_fun->set_function_reference(RegisterFunction("is_null"));
+	auto s_arg = scalar_fun->add_arguments();
+	TransformExpr(*dop.children[0], *s_arg->mutable_value(), col_offset);
+	*scalar_fun->mutable_output_type() = DuckToSubstraitType(dop.return_type);
 }
 
-void DuckDBToSubstrait::TransformNotExpression(Expression &dexpr,
-                                               substrait::Expression &sexpr,
-                                               uint64_t col_offset) {
-  auto &dop = (BoundOperatorExpression &)dexpr;
-  auto scalar_fun = sexpr.mutable_scalar_function();
-  scalar_fun->set_function_reference(RegisterFunction("not"));
-  auto s_arg = scalar_fun->add_arguments();
-  TransformExpr(*dop.children[0], *s_arg->mutable_value(), col_offset);
-  *scalar_fun->mutable_output_type() = DuckToSubstraitType(dop.return_type);
+void DuckDBToSubstrait::TransformNotExpression(Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset) {
+	auto &dop = (BoundOperatorExpression &)dexpr;
+	auto scalar_fun = sexpr.mutable_scalar_function();
+	scalar_fun->set_function_reference(RegisterFunction("not"));
+	auto s_arg = scalar_fun->add_arguments();
+	TransformExpr(*dop.children[0], *s_arg->mutable_value(), col_offset);
+	*scalar_fun->mutable_output_type() = DuckToSubstraitType(dop.return_type);
 }
 
-void DuckDBToSubstrait::TransformExpr(Expression &dexpr,
-                                      substrait::Expression &sexpr,
-                                      uint64_t col_offset) {
-  switch (dexpr.type) {
-  case ExpressionType::BOUND_REF:
-    TransformBoundRefExpression(dexpr, sexpr, col_offset);
-    break;
-  case ExpressionType::OPERATOR_CAST:
-    TransformCastExpression(dexpr, sexpr, col_offset);
-    break;
-  case ExpressionType::BOUND_FUNCTION:
-    TransformFunctionExpression(dexpr, sexpr, col_offset);
-    break;
-  case ExpressionType::VALUE_CONSTANT:
-    TransformConstantExpression(dexpr, sexpr);
-    break;
-  case ExpressionType::COMPARE_EQUAL:
-  case ExpressionType::COMPARE_LESSTHAN:
-  case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-  case ExpressionType::COMPARE_GREATERTHAN:
-  case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-  case ExpressionType::COMPARE_NOTEQUAL:
-  case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
-    TransformComparisonExpression(dexpr, sexpr);
-    break;
-  case ExpressionType::CONJUNCTION_AND:
-  case ExpressionType::CONJUNCTION_OR:
-    TransformConjunctionExpression(dexpr, sexpr, col_offset);
-    break;
-  case ExpressionType::OPERATOR_IS_NOT_NULL:
-    TransformNotNullExpression(dexpr, sexpr, col_offset);
-    break;
-  case ExpressionType::CASE_EXPR:
-    TransformCaseExpression(dexpr, sexpr);
-    break;
-  case ExpressionType::COMPARE_IN:
-    TransformInExpression(dexpr, sexpr);
-    break;
-  case ExpressionType::OPERATOR_IS_NULL:
-    TransformIsNullExpression(dexpr, sexpr, col_offset);
-    break;
-  case ExpressionType::OPERATOR_NOT:
-    TransformNotExpression(dexpr, sexpr, col_offset);
-    break;
-  default:
-    throw InternalException(ExpressionTypeToString(dexpr.type));
-  }
+void DuckDBToSubstrait::TransformExpr(Expression &dexpr, substrait::Expression &sexpr, uint64_t col_offset) {
+	switch (dexpr.type) {
+	case ExpressionType::BOUND_REF:
+		TransformBoundRefExpression(dexpr, sexpr, col_offset);
+		break;
+	case ExpressionType::OPERATOR_CAST:
+		TransformCastExpression(dexpr, sexpr, col_offset);
+		break;
+	case ExpressionType::BOUND_FUNCTION:
+		TransformFunctionExpression(dexpr, sexpr, col_offset);
+		break;
+	case ExpressionType::VALUE_CONSTANT:
+		TransformConstantExpression(dexpr, sexpr);
+		break;
+	case ExpressionType::COMPARE_EQUAL:
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+	case ExpressionType::COMPARE_GREATERTHAN:
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+	case ExpressionType::COMPARE_NOTEQUAL:
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		TransformComparisonExpression(dexpr, sexpr);
+		break;
+	case ExpressionType::CONJUNCTION_AND:
+	case ExpressionType::CONJUNCTION_OR:
+		TransformConjunctionExpression(dexpr, sexpr, col_offset);
+		break;
+	case ExpressionType::OPERATOR_IS_NOT_NULL:
+		TransformNotNullExpression(dexpr, sexpr, col_offset);
+		break;
+	case ExpressionType::CASE_EXPR:
+		TransformCaseExpression(dexpr, sexpr);
+		break;
+	case ExpressionType::COMPARE_IN:
+		TransformInExpression(dexpr, sexpr);
+		break;
+	case ExpressionType::OPERATOR_IS_NULL:
+		TransformIsNullExpression(dexpr, sexpr, col_offset);
+		break;
+	case ExpressionType::OPERATOR_NOT:
+		TransformNotExpression(dexpr, sexpr, col_offset);
+		break;
+	default:
+		throw InternalException(ExpressionTypeToString(dexpr.type));
+	}
 }
 
 uint64_t DuckDBToSubstrait::RegisterFunction(const string &name) {
-  if (name.empty()) {
-    throw InternalException("Missing function name");
-  }
-  if (functions_map.find(name) == functions_map.end()) {
-    auto function_id = last_function_id++;
-    // FIXME: We have to do some URI YAML File shenanigans
-    //		auto uri = plan.add_extension_uris();
-    //		uri->set_extension_uri_anchor(function_id);
-    auto sfun = plan.add_extensions()->mutable_extension_function();
-    sfun->set_function_anchor(function_id);
-    sfun->set_name(name);
-    //		sfun->set_extension_uri_reference(function_id);
+	if (name.empty()) {
+		throw InternalException("Missing function name");
+	}
+	if (functions_map.find(name) == functions_map.end()) {
+		auto function_id = last_function_id++;
+		// FIXME: We have to do some URI YAML File shenanigans
+		//		auto uri = plan.add_extension_uris();
+		//		uri->set_extension_uri_anchor(function_id);
+		auto sfun = plan.add_extensions()->mutable_extension_function();
+		sfun->set_function_anchor(function_id);
+		sfun->set_name(name);
+		//		sfun->set_extension_uri_reference(function_id);
 
-    functions_map[name] = function_id;
-  }
-  return functions_map[name];
+		functions_map[name] = function_id;
+	}
+	return functions_map[name];
 }
 
-void DuckDBToSubstrait::CreateFieldRef(substrait::Expression *expr,
-                                       uint64_t col_idx) {
-  auto selection = new ::substrait::Expression_FieldReference();
-  selection->mutable_direct_reference()->mutable_struct_field()->set_field(
-      (int32_t)col_idx);
-  auto root_reference =
-      new ::substrait::Expression_FieldReference_RootReference();
-  selection->set_allocated_root_reference(root_reference);
-  D_ASSERT(selection->root_type_case() ==
-           substrait::Expression_FieldReference::RootTypeCase::kRootReference);
-  expr->set_allocated_selection(selection);
-  D_ASSERT(expr->has_selection());
+void DuckDBToSubstrait::CreateFieldRef(substrait::Expression *expr, uint64_t col_idx) {
+	auto selection = new ::substrait::Expression_FieldReference();
+	selection->mutable_direct_reference()->mutable_struct_field()->set_field((int32_t)col_idx);
+	auto root_reference = new ::substrait::Expression_FieldReference_RootReference();
+	selection->set_allocated_root_reference(root_reference);
+	D_ASSERT(selection->root_type_case() == substrait::Expression_FieldReference::RootTypeCase::kRootReference);
+	expr->set_allocated_selection(selection);
+	D_ASSERT(expr->has_selection());
 }
 
-substrait::Expression *DuckDBToSubstrait::TransformIsNotNullFilter(
-    uint64_t col_idx, TableFilter &dfilter, LogicalType &return_type) {
-  auto s_expr = new substrait::Expression();
-  auto scalar_fun = s_expr->mutable_scalar_function();
-  scalar_fun->set_function_reference(RegisterFunction("is_not_null"));
-  auto s_arg = scalar_fun->add_arguments();
-  CreateFieldRef(s_arg->mutable_value(), col_idx);
-  *scalar_fun->mutable_output_type() = DuckToSubstraitType(return_type);
-  return s_expr;
+substrait::Expression *DuckDBToSubstrait::TransformIsNotNullFilter(uint64_t col_idx, TableFilter &dfilter,
+                                                                   LogicalType &return_type) {
+	auto s_expr = new substrait::Expression();
+	auto scalar_fun = s_expr->mutable_scalar_function();
+	scalar_fun->set_function_reference(RegisterFunction("is_not_null"));
+	auto s_arg = scalar_fun->add_arguments();
+	CreateFieldRef(s_arg->mutable_value(), col_idx);
+	*scalar_fun->mutable_output_type() = DuckToSubstraitType(return_type);
+	return s_expr;
 }
 
-substrait::Expression *DuckDBToSubstrait::TransformConjuctionAndFilter(
-    uint64_t col_idx, TableFilter &dfilter, LogicalType &return_type) {
-  auto &conjunction_filter = (ConjunctionAndFilter &)dfilter;
-  return CreateConjunction(conjunction_filter.child_filters,
-                           [&](unique_ptr<TableFilter> &in) {
-                             return TransformFilter(col_idx, *in, return_type);
-                           });
+substrait::Expression *DuckDBToSubstrait::TransformConjuctionAndFilter(uint64_t col_idx, TableFilter &dfilter,
+                                                                       LogicalType &return_type) {
+	auto &conjunction_filter = (ConjunctionAndFilter &)dfilter;
+	return CreateConjunction(conjunction_filter.child_filters,
+	                         [&](unique_ptr<TableFilter> &in) { return TransformFilter(col_idx, *in, return_type); });
 }
 
-substrait::Expression *DuckDBToSubstrait::TransformConstantComparisonFilter(
-    uint64_t col_idx, TableFilter &dfilter, LogicalType &return_type) {
-  auto s_expr = new substrait::Expression();
-  auto s_scalar = s_expr->mutable_scalar_function();
-  auto &constant_filter = (ConstantFilter &)dfilter;
-  *s_scalar->mutable_output_type() = DuckToSubstraitType(return_type);
-  auto s_arg = s_scalar->add_arguments();
-  CreateFieldRef(s_arg->mutable_value(), col_idx);
-  s_arg = s_scalar->add_arguments();
-  TransformConstant(constant_filter.constant, *s_arg->mutable_value());
-  uint64_t function_id;
-  switch (constant_filter.comparison_type) {
-  case ExpressionType::COMPARE_EQUAL:
-    function_id = RegisterFunction("equal");
-    break;
-  case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-    function_id = RegisterFunction("lte");
-    break;
-  case ExpressionType::COMPARE_LESSTHAN:
-    function_id = RegisterFunction("lt");
-    break;
-  case ExpressionType::COMPARE_GREATERTHAN:
-    function_id = RegisterFunction("gt");
-    break;
-  case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-    function_id = RegisterFunction("gte");
-    break;
-  default:
-    throw InternalException(
-        ExpressionTypeToString(constant_filter.comparison_type));
-  }
-  s_scalar->set_function_reference(function_id);
-  return s_expr;
+substrait::Expression *DuckDBToSubstrait::TransformConstantComparisonFilter(uint64_t col_idx, TableFilter &dfilter,
+                                                                            LogicalType &return_type) {
+	auto s_expr = new substrait::Expression();
+	auto s_scalar = s_expr->mutable_scalar_function();
+	auto &constant_filter = (ConstantFilter &)dfilter;
+	*s_scalar->mutable_output_type() = DuckToSubstraitType(return_type);
+	auto s_arg = s_scalar->add_arguments();
+	CreateFieldRef(s_arg->mutable_value(), col_idx);
+	s_arg = s_scalar->add_arguments();
+	TransformConstant(constant_filter.constant, *s_arg->mutable_value());
+	uint64_t function_id;
+	switch (constant_filter.comparison_type) {
+	case ExpressionType::COMPARE_EQUAL:
+		function_id = RegisterFunction("equal");
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		function_id = RegisterFunction("lte");
+		break;
+	case ExpressionType::COMPARE_LESSTHAN:
+		function_id = RegisterFunction("lt");
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		function_id = RegisterFunction("gt");
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		function_id = RegisterFunction("gte");
+		break;
+	default:
+		throw InternalException(ExpressionTypeToString(constant_filter.comparison_type));
+	}
+	s_scalar->set_function_reference(function_id);
+	return s_expr;
 }
 
-substrait::Expression *
-DuckDBToSubstrait::TransformFilter(uint64_t col_idx, TableFilter &dfilter,
-                                   LogicalType &return_type) {
-  switch (dfilter.filter_type) {
-  case TableFilterType::IS_NOT_NULL:
-    return TransformIsNotNullFilter(col_idx, dfilter, return_type);
-  case TableFilterType::CONJUNCTION_AND:
-    return TransformConjuctionAndFilter(col_idx, dfilter, return_type);
-  case TableFilterType::CONSTANT_COMPARISON:
-    return TransformConstantComparisonFilter(col_idx, dfilter, return_type);
-  default:
-    throw InternalException("Unsupported table filter type");
-  }
+substrait::Expression *DuckDBToSubstrait::TransformFilter(uint64_t col_idx, TableFilter &dfilter,
+                                                          LogicalType &return_type) {
+	switch (dfilter.filter_type) {
+	case TableFilterType::IS_NOT_NULL:
+		return TransformIsNotNullFilter(col_idx, dfilter, return_type);
+	case TableFilterType::CONJUNCTION_AND:
+		return TransformConjuctionAndFilter(col_idx, dfilter, return_type);
+	case TableFilterType::CONSTANT_COMPARISON:
+		return TransformConstantComparisonFilter(col_idx, dfilter, return_type);
+	default:
+		throw InternalException("Unsupported table filter type");
+	}
 }
 
-substrait::Expression *
-DuckDBToSubstrait::TransformJoinCond(JoinCondition &dcond, uint64_t left_ncol) {
-  auto expr = new substrait::Expression();
-  string join_comparision;
-  switch (dcond.comparison) {
-  case ExpressionType::COMPARE_EQUAL:
-    join_comparision = "equal";
-    break;
-  case ExpressionType::COMPARE_GREATERTHAN:
-    join_comparision = "gt";
-    break;
-  case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
-    join_comparision = "is_not_distinct_from";
-    break;
-  case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-    join_comparision = "gte";
-    break;
-  case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-    join_comparision = "lte";
-    break;
-  default:
-    throw InternalException("Unsupported join comparison");
-  }
-  auto scalar_fun = expr->mutable_scalar_function();
-  scalar_fun->set_function_reference(RegisterFunction(join_comparision));
-  auto s_arg = scalar_fun->add_arguments();
-  TransformExpr(*dcond.left, *s_arg->mutable_value());
-  s_arg = scalar_fun->add_arguments();
-  TransformExpr(*dcond.right, *s_arg->mutable_value(), left_ncol);
-  LogicalType bool_type = LogicalType::BOOLEAN;
-  *scalar_fun->mutable_output_type() = DuckToSubstraitType(bool_type);
-  return expr;
+substrait::Expression *DuckDBToSubstrait::TransformJoinCond(JoinCondition &dcond, uint64_t left_ncol) {
+	auto expr = new substrait::Expression();
+	string join_comparision;
+	switch (dcond.comparison) {
+	case ExpressionType::COMPARE_EQUAL:
+		join_comparision = "equal";
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		join_comparision = "gt";
+		break;
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		join_comparision = "is_not_distinct_from";
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		join_comparision = "gte";
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		join_comparision = "lte";
+		break;
+	default:
+		throw InternalException("Unsupported join comparison");
+	}
+	auto scalar_fun = expr->mutable_scalar_function();
+	scalar_fun->set_function_reference(RegisterFunction(join_comparision));
+	auto s_arg = scalar_fun->add_arguments();
+	TransformExpr(*dcond.left, *s_arg->mutable_value());
+	s_arg = scalar_fun->add_arguments();
+	TransformExpr(*dcond.right, *s_arg->mutable_value(), left_ncol);
+	LogicalType bool_type = LogicalType::BOOLEAN;
+	*scalar_fun->mutable_output_type() = DuckToSubstraitType(bool_type);
+	return expr;
 }
 
-void DuckDBToSubstrait::TransformOrder(BoundOrderByNode &dordf,
-                                       substrait::SortField &sordf) {
-  switch (dordf.type) {
-  case OrderType::ASCENDING:
-    switch (dordf.null_order) {
-    case OrderByNullType::NULLS_FIRST:
-      sordf.set_direction(
-          substrait::SortField_SortDirection::
-              SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_FIRST);
-      break;
-    case OrderByNullType::NULLS_LAST:
-      sordf.set_direction(
-          substrait::SortField_SortDirection::
-              SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_LAST);
+void DuckDBToSubstrait::TransformOrder(BoundOrderByNode &dordf, substrait::SortField &sordf) {
+	switch (dordf.type) {
+	case OrderType::ASCENDING:
+		switch (dordf.null_order) {
+		case OrderByNullType::NULLS_FIRST:
+			sordf.set_direction(
+			    substrait::SortField_SortDirection::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_FIRST);
+			break;
+		case OrderByNullType::NULLS_LAST:
+			sordf.set_direction(
+			    substrait::SortField_SortDirection::SortField_SortDirection_SORT_DIRECTION_ASC_NULLS_LAST);
 
-      break;
-    default:
-      throw InternalException("Unsupported ordering type");
-    }
-    break;
-  case OrderType::DESCENDING:
-    switch (dordf.null_order) {
-    case OrderByNullType::NULLS_FIRST:
-      sordf.set_direction(
-          substrait::SortField_SortDirection::
-              SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_FIRST);
-      break;
-    case OrderByNullType::NULLS_LAST:
-      sordf.set_direction(
-          substrait::SortField_SortDirection::
-              SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST);
+			break;
+		default:
+			throw InternalException("Unsupported ordering type");
+		}
+		break;
+	case OrderType::DESCENDING:
+		switch (dordf.null_order) {
+		case OrderByNullType::NULLS_FIRST:
+			sordf.set_direction(
+			    substrait::SortField_SortDirection::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_FIRST);
+			break;
+		case OrderByNullType::NULLS_LAST:
+			sordf.set_direction(
+			    substrait::SortField_SortDirection::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST);
 
-      break;
-    default:
-      throw InternalException("Unsupported ordering type");
-    }
-    break;
-  default:
-    throw InternalException("Unsupported ordering type");
-  }
-  TransformExpr(*dordf.expression, *sordf.mutable_expr());
+			break;
+		default:
+			throw InternalException("Unsupported ordering type");
+		}
+		break;
+	default:
+		throw InternalException("Unsupported ordering type");
+	}
+	TransformExpr(*dordf.expression, *sordf.mutable_expr());
 }
 
 substrait::Rel *DuckDBToSubstrait::TransformFilter(LogicalOperator &dop) {
 
-  auto &dfilter = (LogicalFilter &)dop;
+	auto &dfilter = (LogicalFilter &)dop;
 
-  auto res = TransformOp(*dop.children[0]);
+	auto res = TransformOp(*dop.children[0]);
 
-  if (!dfilter.expressions.empty()) {
-    auto filter = new substrait::Rel();
-    filter->mutable_filter()->set_allocated_input(res);
-    filter->mutable_filter()->set_allocated_condition(
-        CreateConjunction(dfilter.expressions, [&](unique_ptr<Expression> &in) {
-          auto expr = new substrait::Expression();
-          TransformExpr(*in, *expr);
-          return expr;
-        }));
-    res = filter;
-  }
+	if (!dfilter.expressions.empty()) {
+		auto filter = new substrait::Rel();
+		filter->mutable_filter()->set_allocated_input(res);
+		filter->mutable_filter()->set_allocated_condition(
+		    CreateConjunction(dfilter.expressions, [&](unique_ptr<Expression> &in) {
+			    auto expr = new substrait::Expression();
+			    TransformExpr(*in, *expr);
+			    return expr;
+		    }));
+		res = filter;
+	}
 
-  if (!dfilter.projection_map.empty()) {
-    auto projection = new substrait::Rel();
-    projection->mutable_project()->set_allocated_input(res);
-    for (auto col_idx : dfilter.projection_map) {
-      CreateFieldRef(projection->mutable_project()->add_expressions(), col_idx);
-    }
-    res = projection;
-  }
-  return res;
+	if (!dfilter.projection_map.empty()) {
+		auto projection = new substrait::Rel();
+		projection->mutable_project()->set_allocated_input(res);
+		for (auto col_idx : dfilter.projection_map) {
+			CreateFieldRef(projection->mutable_project()->add_expressions(), col_idx);
+		}
+		res = projection;
+	}
+	return res;
 }
 
 substrait::Rel *DuckDBToSubstrait::TransformProjection(LogicalOperator &dop) {
-  auto res = new substrait::Rel();
-  auto &dproj = (LogicalProjection &)dop;
-  auto sproj = res->mutable_project();
-  sproj->set_allocated_input(TransformOp(*dop.children[0]));
+	auto res = new substrait::Rel();
+	auto &dproj = (LogicalProjection &)dop;
+	auto sproj = res->mutable_project();
+	sproj->set_allocated_input(TransformOp(*dop.children[0]));
 
-  for (auto &dexpr : dproj.expressions) {
-    TransformExpr(*dexpr, *sproj->add_expressions());
-  }
-  return res;
+	for (auto &dexpr : dproj.expressions) {
+		TransformExpr(*dexpr, *sproj->add_expressions());
+	}
+	return res;
 }
 
 substrait::Rel *DuckDBToSubstrait::TransformTopN(LogicalOperator &dop) {
-  auto &dtopn = (LogicalTopN &)dop;
-  auto res = new substrait::Rel();
-  auto stopn = res->mutable_fetch();
+	auto &dtopn = (LogicalTopN &)dop;
+	auto res = new substrait::Rel();
+	auto stopn = res->mutable_fetch();
 
-  auto sord_rel = new substrait::Rel();
-  auto sord = sord_rel->mutable_sort();
-  sord->set_allocated_input(TransformOp(*dop.children[0]));
+	auto sord_rel = new substrait::Rel();
+	auto sord = sord_rel->mutable_sort();
+	sord->set_allocated_input(TransformOp(*dop.children[0]));
 
-  for (auto &dordf : dtopn.orders) {
-    TransformOrder(dordf, *sord->add_sorts());
-  }
+	for (auto &dordf : dtopn.orders) {
+		TransformOrder(dordf, *sord->add_sorts());
+	}
 
-  stopn->set_allocated_input(sord_rel);
-  stopn->set_offset(dtopn.offset);
-  stopn->set_count(dtopn.limit);
-  return res;
+	stopn->set_allocated_input(sord_rel);
+	stopn->set_offset(dtopn.offset);
+	stopn->set_count(dtopn.limit);
+	return res;
 }
 
 substrait::Rel *DuckDBToSubstrait::TransformLimit(LogicalOperator &dop) {
-  auto &dlimit = (LogicalLimit &)dop;
-  auto res = new substrait::Rel();
-  auto stopn = res->mutable_fetch();
-  stopn->set_allocated_input(TransformOp(*dop.children[0]));
+	auto &dlimit = (LogicalLimit &)dop;
+	auto res = new substrait::Rel();
+	auto stopn = res->mutable_fetch();
+	stopn->set_allocated_input(TransformOp(*dop.children[0]));
 
-  stopn->set_offset(dlimit.offset_val);
-  stopn->set_count(dlimit.limit_val);
-  return res;
+	stopn->set_offset(dlimit.offset_val);
+	stopn->set_count(dlimit.limit_val);
+	return res;
 }
 
 substrait::Rel *DuckDBToSubstrait::TransformOrderBy(LogicalOperator &dop) {
-  auto res = new substrait::Rel();
-  auto &dord = (LogicalOrder &)dop;
-  auto sord = res->mutable_sort();
+	auto res = new substrait::Rel();
+	auto &dord = (LogicalOrder &)dop;
+	auto sord = res->mutable_sort();
 
-  sord->set_allocated_input(TransformOp(*dop.children[0]));
+	sord->set_allocated_input(TransformOp(*dop.children[0]));
 
-  for (auto &dordf : dord.orders) {
-    TransformOrder(dordf, *sord->add_sorts());
-  }
-  return res;
+	for (auto &dordf : dord.orders) {
+		TransformOrder(dordf, *sord->add_sorts());
+	}
+	return res;
 }
 
-substrait::Rel *
-DuckDBToSubstrait::TransformComparisonJoin(LogicalOperator &dop) {
-  auto res = new substrait::Rel();
-  auto sjoin = res->mutable_join();
-  auto &djoin = (LogicalComparisonJoin &)dop;
-  sjoin->set_allocated_left(TransformOp(*dop.children[0]));
-  sjoin->set_allocated_right(TransformOp(*dop.children[1]));
+substrait::Rel *DuckDBToSubstrait::TransformComparisonJoin(LogicalOperator &dop) {
+	auto res = new substrait::Rel();
+	auto sjoin = res->mutable_join();
+	auto &djoin = (LogicalComparisonJoin &)dop;
+	sjoin->set_allocated_left(TransformOp(*dop.children[0]));
+	sjoin->set_allocated_right(TransformOp(*dop.children[1]));
 
-  auto left_col_count = dop.children[0]->types.size();
-  if (dop.children[0]->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
-    auto child_join = (LogicalComparisonJoin *)dop.children[0].get();
-    left_col_count = child_join->left_projection_map.size() +
-                     child_join->right_projection_map.size();
-  }
-  sjoin->set_allocated_expression(
-      CreateConjunction(djoin.conditions, [&](JoinCondition &in) {
-        return TransformJoinCond(in, left_col_count);
-      }));
+	auto left_col_count = dop.children[0]->types.size();
+	if (dop.children[0]->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto child_join = (LogicalComparisonJoin *)dop.children[0].get();
+		left_col_count = child_join->left_projection_map.size() + child_join->right_projection_map.size();
+	}
+	sjoin->set_allocated_expression(
+	    CreateConjunction(djoin.conditions, [&](JoinCondition &in) { return TransformJoinCond(in, left_col_count); }));
 
-  switch (djoin.join_type) {
-  case JoinType::INNER:
-    sjoin->set_type(
-        substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_INNER);
-    break;
-  case JoinType::LEFT:
-    sjoin->set_type(
-        substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT);
-    break;
-  case JoinType::RIGHT:
-    sjoin->set_type(
-        substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT);
-    break;
-  case JoinType::SINGLE:
-    sjoin->set_type(
-        substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_SINGLE);
-    break;
-  case JoinType::SEMI:
-    sjoin->set_type(
-        substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_SEMI);
-    break;
-  default:
-    throw InternalException("Unsupported join type " +
-                            JoinTypeToString(djoin.join_type));
-  }
-  // somewhat odd semantics on our side
-  if (djoin.left_projection_map.empty()) {
-    for (uint64_t i = 0; i < dop.children[0]->types.size(); i++) {
-      djoin.left_projection_map.push_back(i);
-    }
-  }
-  if (djoin.right_projection_map.empty()) {
-    for (uint64_t i = 0; i < dop.children[1]->types.size(); i++) {
-      djoin.right_projection_map.push_back(i);
-    }
-  }
-  auto proj_rel = new substrait::Rel();
-  auto projection = proj_rel->mutable_project();
-  for (auto left_idx : djoin.left_projection_map) {
-    CreateFieldRef(projection->add_expressions(), left_idx);
-  }
+	switch (djoin.join_type) {
+	case JoinType::INNER:
+		sjoin->set_type(substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_INNER);
+		break;
+	case JoinType::LEFT:
+		sjoin->set_type(substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT);
+		break;
+	case JoinType::RIGHT:
+		sjoin->set_type(substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT);
+		break;
+	case JoinType::SINGLE:
+		sjoin->set_type(substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_SINGLE);
+		break;
+	case JoinType::SEMI:
+		sjoin->set_type(substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_SEMI);
+		break;
+	default:
+		throw InternalException("Unsupported join type " + JoinTypeToString(djoin.join_type));
+	}
+	// somewhat odd semantics on our side
+	if (djoin.left_projection_map.empty()) {
+		for (uint64_t i = 0; i < dop.children[0]->types.size(); i++) {
+			djoin.left_projection_map.push_back(i);
+		}
+	}
+	if (djoin.right_projection_map.empty()) {
+		for (uint64_t i = 0; i < dop.children[1]->types.size(); i++) {
+			djoin.right_projection_map.push_back(i);
+		}
+	}
+	auto proj_rel = new substrait::Rel();
+	auto projection = proj_rel->mutable_project();
+	for (auto left_idx : djoin.left_projection_map) {
+		CreateFieldRef(projection->add_expressions(), left_idx);
+	}
 
-  for (auto right_idx : djoin.right_projection_map) {
-    CreateFieldRef(projection->add_expressions(), right_idx + left_col_count);
-  }
-  projection->set_allocated_input(res);
-  return proj_rel;
+	for (auto right_idx : djoin.right_projection_map) {
+		CreateFieldRef(projection->add_expressions(), right_idx + left_col_count);
+	}
+	projection->set_allocated_input(res);
+	return proj_rel;
 }
 
-substrait::Rel *
-DuckDBToSubstrait::TransformAggregateGroup(LogicalOperator &dop) {
-  auto res = new substrait::Rel();
-  auto &daggr = (LogicalAggregate &)dop;
-  auto saggr = res->mutable_aggregate();
-  saggr->set_allocated_input(TransformOp(*dop.children[0]));
-  // we only do a single grouping set for now
-  auto sgrp = saggr->add_groupings();
-  for (auto &dgrp : daggr.groups) {
-    if (dgrp->type != ExpressionType::BOUND_REF) {
-      // TODO push projection or push substrait to allow expressions here
-      throw InternalException("No expressions in groupings yet");
-    }
-    TransformExpr(*dgrp, *sgrp->add_grouping_expressions());
-  }
-  for (auto &dmeas : daggr.expressions) {
-    auto smeas = saggr->add_measures()->mutable_measure();
-    if (dmeas->type != ExpressionType::BOUND_AGGREGATE) {
-      // TODO push projection or push substrait, too
-      throw InternalException("No non-aggregate expressions in measures yet");
-    }
-    auto &daexpr = (BoundAggregateExpression &)*dmeas;
+substrait::Rel *DuckDBToSubstrait::TransformAggregateGroup(LogicalOperator &dop) {
+	auto res = new substrait::Rel();
+	auto &daggr = (LogicalAggregate &)dop;
+	auto saggr = res->mutable_aggregate();
+	saggr->set_allocated_input(TransformOp(*dop.children[0]));
+	// we only do a single grouping set for now
+	auto sgrp = saggr->add_groupings();
+	for (auto &dgrp : daggr.groups) {
+		if (dgrp->type != ExpressionType::BOUND_REF) {
+			// TODO push projection or push substrait to allow expressions here
+			throw InternalException("No expressions in groupings yet");
+		}
+		TransformExpr(*dgrp, *sgrp->add_grouping_expressions());
+	}
+	for (auto &dmeas : daggr.expressions) {
+		auto smeas = saggr->add_measures()->mutable_measure();
+		if (dmeas->type != ExpressionType::BOUND_AGGREGATE) {
+			// TODO push projection or push substrait, too
+			throw InternalException("No non-aggregate expressions in measures yet");
+		}
+		auto &daexpr = (BoundAggregateExpression &)*dmeas;
 
-    smeas->set_function_reference(
-        RegisterFunction(RemapFunctionName(daexpr.function.name)));
+		smeas->set_function_reference(RegisterFunction(RemapFunctionName(daexpr.function.name)));
 
-    *smeas->mutable_output_type() = DuckToSubstraitType(daexpr.return_type);
-    for (auto &darg : daexpr.children) {
-      auto s_arg = smeas->add_arguments();
-      TransformExpr(*darg, *s_arg->mutable_value());
-    }
-  }
-  return res;
+		*smeas->mutable_output_type() = DuckToSubstraitType(daexpr.return_type);
+		for (auto &darg : daexpr.children) {
+			auto s_arg = smeas->add_arguments();
+			TransformExpr(*darg, *s_arg->mutable_value());
+		}
+	}
+	return res;
 }
 
-::substrait::Type DuckDBToSubstrait::DuckToSubstraitType(
-    const LogicalType &type, BaseStatistics *column_statistics, bool not_null) {
-  ::substrait::Type s_type;
-  substrait::Type_Nullability type_nullability;
-  if (not_null) {
-    type_nullability =
-        substrait::Type_Nullability::Type_Nullability_NULLABILITY_REQUIRED;
-  } else {
-    type_nullability =
-        substrait::Type_Nullability::Type_Nullability_NULLABILITY_NULLABLE;
-  }
-  switch (type.id()) {
-  case LogicalTypeId::BOOLEAN: {
-    auto bool_type = new substrait::Type_Boolean;
-    bool_type->set_nullability(type_nullability);
-    s_type.set_allocated_bool_(bool_type);
-    return s_type;
-  }
+::substrait::Type DuckDBToSubstrait::DuckToSubstraitType(const LogicalType &type, BaseStatistics *column_statistics,
+                                                         bool not_null) {
+	::substrait::Type s_type;
+	substrait::Type_Nullability type_nullability;
+	if (not_null) {
+		type_nullability = substrait::Type_Nullability::Type_Nullability_NULLABILITY_REQUIRED;
+	} else {
+		type_nullability = substrait::Type_Nullability::Type_Nullability_NULLABILITY_NULLABLE;
+	}
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN: {
+		auto bool_type = new substrait::Type_Boolean;
+		bool_type->set_nullability(type_nullability);
+		s_type.set_allocated_bool_(bool_type);
+		return s_type;
+	}
 
-  case LogicalTypeId::TINYINT: {
-    auto integral_type = new substrait::Type_I8;
-    integral_type->set_nullability(type_nullability);
-    s_type.set_allocated_i8(integral_type);
-    return s_type;
-  }
-    // Substrait ppl think unsigned types are not common, so we have to upcast
-    // these beauties Which completely borks the optimization they are created
-    // for
-  case LogicalTypeId::UTINYINT:
-  case LogicalTypeId::SMALLINT: {
-    auto integral_type = new substrait::Type_I16;
-    integral_type->set_nullability(type_nullability);
-    s_type.set_allocated_i16(integral_type);
-    return s_type;
-  }
-  case LogicalTypeId::USMALLINT:
-  case LogicalTypeId::INTEGER: {
-    auto integral_type = new substrait::Type_I32;
-    integral_type->set_nullability(type_nullability);
-    s_type.set_allocated_i32(integral_type);
-    return s_type;
-  }
-  case LogicalTypeId::UINTEGER:
-  case LogicalTypeId::BIGINT: {
-    auto integral_type = new substrait::Type_I64;
-    integral_type->set_nullability(type_nullability);
-    s_type.set_allocated_i64(integral_type);
-    return s_type;
-  }
-  case LogicalTypeId::UBIGINT:
-  case LogicalTypeId::HUGEINT: {
-    // FIXME: Support for hugeint types?
-    auto s_decimal = new substrait::Type_Decimal();
-    s_decimal->set_scale(0);
-    s_decimal->set_precision(38);
-    s_decimal->set_nullability(type_nullability);
-    s_type.set_allocated_decimal(s_decimal);
-    return s_type;
-  }
-  case LogicalTypeId::DATE: {
-    auto date_type = new substrait::Type_Date;
-    date_type->set_nullability(type_nullability);
-    s_type.set_allocated_date(date_type);
-    return s_type;
-  }
-  case LogicalTypeId::TIME_TZ:
-  case LogicalTypeId::TIME: {
-    auto time_type = new substrait::Type_Time;
-    time_type->set_nullability(type_nullability);
-    s_type.set_allocated_time(time_type);
-    return s_type;
-  }
-  case LogicalTypeId::TIMESTAMP:
-  case LogicalTypeId::TIMESTAMP_MS:
-  case LogicalTypeId::TIMESTAMP_NS:
-  case LogicalTypeId::TIMESTAMP_SEC: {
-    // FIXME: Shouldn't this have a precision?
-    auto timestamp_type = new substrait::Type_Timestamp;
-    timestamp_type->set_nullability(type_nullability);
-    s_type.set_allocated_timestamp(timestamp_type);
-    return s_type;
-  }
-  case LogicalTypeId::TIMESTAMP_TZ: {
-    auto timestamp_type = new substrait::Type_TimestampTZ;
-    timestamp_type->set_nullability(type_nullability);
-    s_type.set_allocated_timestamp_tz(timestamp_type);
-    return s_type;
-  }
-  case LogicalTypeId::INTERVAL: {
-    auto interval_type = new substrait::Type_IntervalDay();
-    interval_type->set_nullability(type_nullability);
-    s_type.set_allocated_interval_day(interval_type);
-    return s_type;
-  }
-  case LogicalTypeId::FLOAT: {
-    auto float_type = new substrait::Type_FP32;
-    float_type->set_nullability(type_nullability);
-    s_type.set_allocated_fp32(float_type);
-    return s_type;
-  }
-  case LogicalTypeId::DOUBLE: {
-    auto double_type = new substrait::Type_FP64;
-    double_type->set_nullability(type_nullability);
-    s_type.set_allocated_fp64(double_type);
-    return s_type;
-  }
-  case LogicalTypeId::DECIMAL: {
-    auto decimal_type = new substrait::Type_Decimal;
-    decimal_type->set_nullability(type_nullability);
-    decimal_type->set_precision(DecimalType::GetWidth(type));
-    decimal_type->set_scale(DecimalType::GetScale(type));
-    s_type.set_allocated_decimal(decimal_type);
-    return s_type;
-  }
-  case LogicalTypeId::VARCHAR: {
-    auto varchar_type = new substrait::Type_VarChar;
-    varchar_type->set_nullability(type_nullability);
-    if (column_statistics) {
-      auto string_statistics = (StringStatistics *)column_statistics;
-      if (max_string_length < string_statistics->max_string_length) {
-        max_string_length = string_statistics->max_string_length;
-      }
-      varchar_type->set_length(string_statistics->max_string_length);
-    } else {
-      // FIXME: Have to propagate the statistics to here somehow
-      varchar_type->set_length(max_string_length);
-    }
-    s_type.set_allocated_varchar(varchar_type);
-    return s_type;
-  }
-  case LogicalTypeId::BLOB: {
-    auto binary_type = new substrait::Type_Binary;
-    binary_type->set_nullability(type_nullability);
-    s_type.set_allocated_binary(binary_type);
-    return s_type;
-  }
-  case LogicalTypeId::UUID: {
-    auto uuid_type = new substrait::Type_UUID;
-    uuid_type->set_nullability(type_nullability);
-    s_type.set_allocated_uuid(uuid_type);
-    return s_type;
-  }
-  case LogicalTypeId::ENUM: {
-    auto enum_type = new substrait::Type_UserDefined;
-    enum_type->set_nullability(type_nullability);
-    s_type.set_allocated_user_defined(enum_type);
-    return s_type;
-  }
-  default:
-    throw NotImplementedException(
-        "Logical Type " + type.ToString() +
-        " not implemented as Substrait Schema Result.");
-  }
+	case LogicalTypeId::TINYINT: {
+		auto integral_type = new substrait::Type_I8;
+		integral_type->set_nullability(type_nullability);
+		s_type.set_allocated_i8(integral_type);
+		return s_type;
+	}
+		// Substrait ppl think unsigned types are not common, so we have to upcast
+		// these beauties Which completely borks the optimization they are created
+		// for
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::SMALLINT: {
+		auto integral_type = new substrait::Type_I16;
+		integral_type->set_nullability(type_nullability);
+		s_type.set_allocated_i16(integral_type);
+		return s_type;
+	}
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::INTEGER: {
+		auto integral_type = new substrait::Type_I32;
+		integral_type->set_nullability(type_nullability);
+		s_type.set_allocated_i32(integral_type);
+		return s_type;
+	}
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::BIGINT: {
+		auto integral_type = new substrait::Type_I64;
+		integral_type->set_nullability(type_nullability);
+		s_type.set_allocated_i64(integral_type);
+		return s_type;
+	}
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::HUGEINT: {
+		// FIXME: Support for hugeint types?
+		auto s_decimal = new substrait::Type_Decimal();
+		s_decimal->set_scale(0);
+		s_decimal->set_precision(38);
+		s_decimal->set_nullability(type_nullability);
+		s_type.set_allocated_decimal(s_decimal);
+		return s_type;
+	}
+	case LogicalTypeId::DATE: {
+		auto date_type = new substrait::Type_Date;
+		date_type->set_nullability(type_nullability);
+		s_type.set_allocated_date(date_type);
+		return s_type;
+	}
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::TIME: {
+		auto time_type = new substrait::Type_Time;
+		time_type->set_nullability(type_nullability);
+		s_type.set_allocated_time(time_type);
+		return s_type;
+	}
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_SEC: {
+		// FIXME: Shouldn't this have a precision?
+		auto timestamp_type = new substrait::Type_Timestamp;
+		timestamp_type->set_nullability(type_nullability);
+		s_type.set_allocated_timestamp(timestamp_type);
+		return s_type;
+	}
+	case LogicalTypeId::TIMESTAMP_TZ: {
+		auto timestamp_type = new substrait::Type_TimestampTZ;
+		timestamp_type->set_nullability(type_nullability);
+		s_type.set_allocated_timestamp_tz(timestamp_type);
+		return s_type;
+	}
+	case LogicalTypeId::INTERVAL: {
+		auto interval_type = new substrait::Type_IntervalDay();
+		interval_type->set_nullability(type_nullability);
+		s_type.set_allocated_interval_day(interval_type);
+		return s_type;
+	}
+	case LogicalTypeId::FLOAT: {
+		auto float_type = new substrait::Type_FP32;
+		float_type->set_nullability(type_nullability);
+		s_type.set_allocated_fp32(float_type);
+		return s_type;
+	}
+	case LogicalTypeId::DOUBLE: {
+		auto double_type = new substrait::Type_FP64;
+		double_type->set_nullability(type_nullability);
+		s_type.set_allocated_fp64(double_type);
+		return s_type;
+	}
+	case LogicalTypeId::DECIMAL: {
+		auto decimal_type = new substrait::Type_Decimal;
+		decimal_type->set_nullability(type_nullability);
+		decimal_type->set_precision(DecimalType::GetWidth(type));
+		decimal_type->set_scale(DecimalType::GetScale(type));
+		s_type.set_allocated_decimal(decimal_type);
+		return s_type;
+	}
+	case LogicalTypeId::VARCHAR: {
+		auto varchar_type = new substrait::Type_VarChar;
+		varchar_type->set_nullability(type_nullability);
+		if (column_statistics) {
+			auto string_statistics = (StringStatistics *)column_statistics;
+			if (max_string_length < string_statistics->max_string_length) {
+				max_string_length = string_statistics->max_string_length;
+			}
+			varchar_type->set_length(string_statistics->max_string_length);
+		} else {
+			// FIXME: Have to propagate the statistics to here somehow
+			varchar_type->set_length(max_string_length);
+		}
+		s_type.set_allocated_varchar(varchar_type);
+		return s_type;
+	}
+	case LogicalTypeId::BLOB: {
+		auto binary_type = new substrait::Type_Binary;
+		binary_type->set_nullability(type_nullability);
+		s_type.set_allocated_binary(binary_type);
+		return s_type;
+	}
+	case LogicalTypeId::UUID: {
+		auto uuid_type = new substrait::Type_UUID;
+		uuid_type->set_nullability(type_nullability);
+		s_type.set_allocated_uuid(uuid_type);
+		return s_type;
+	}
+	case LogicalTypeId::ENUM: {
+		auto enum_type = new substrait::Type_UserDefined;
+		enum_type->set_nullability(type_nullability);
+		s_type.set_allocated_user_defined(enum_type);
+		return s_type;
+	}
+	default:
+		throw NotImplementedException("Logical Type " + type.ToString() +
+		                              " not implemented as Substrait Schema Result.");
+	}
 }
 
 set<idx_t> GetNotNullConstraintCol(TableCatalogEntry &tbl) {
-  set<idx_t> not_null;
-  for (auto &constraint : tbl.GetConstraints()) {
-    if (constraint->type == ConstraintType::NOT_NULL) {
-      not_null.insert(((NotNullConstraint *)constraint.get())->index.index);
-    }
-  }
-  return not_null;
+	set<idx_t> not_null;
+	for (auto &constraint : tbl.GetConstraints()) {
+		if (constraint->type == ConstraintType::NOT_NULL) {
+			not_null.insert(((NotNullConstraint *)constraint.get())->index.index);
+		}
+	}
+	return not_null;
 }
 
-void DuckDBToSubstrait::TransformTableScanToSubstrait(
-    LogicalGet &dget, substrait::ReadRel *sget) {
-  auto &table_scan_bind_data = (TableScanBindData &)*dget.bind_data;
-  sget->mutable_named_table()->add_names(table_scan_bind_data.table->name);
-  auto base_schema = new ::substrait::NamedStruct();
-  auto type_info = new substrait::Type_Struct();
-  type_info->set_nullability(substrait::Type_Nullability_NULLABILITY_REQUIRED);
-  auto not_null_constraint =
-      GetNotNullConstraintCol(*table_scan_bind_data.table);
-  for (idx_t i = 0; i < dget.names.size(); i++) {
-    auto cur_type = dget.returned_types[i];
-    if (cur_type.id() == LogicalTypeId::STRUCT) {
-      throw std::runtime_error("Structs are not yet accepted in table scans");
-    }
-    base_schema->add_names(dget.names[i]);
-    auto column_statistics =
-        dget.function.statistics(context, &table_scan_bind_data, i);
-    bool not_null = not_null_constraint.find(i) != not_null_constraint.end();
-    auto new_type = type_info->add_types();
-    *new_type =
-        DuckToSubstraitType(cur_type, column_statistics.get(), not_null);
-  }
-  base_schema->set_allocated_struct_(type_info);
-  sget->set_allocated_base_schema(base_schema);
+void DuckDBToSubstrait::TransformTableScanToSubstrait(LogicalGet &dget, substrait::ReadRel *sget) {
+	auto &table_scan_bind_data = (TableScanBindData &)*dget.bind_data;
+	sget->mutable_named_table()->add_names(table_scan_bind_data.table->name);
+	auto base_schema = new ::substrait::NamedStruct();
+	auto type_info = new substrait::Type_Struct();
+	type_info->set_nullability(substrait::Type_Nullability_NULLABILITY_REQUIRED);
+	auto not_null_constraint = GetNotNullConstraintCol(*table_scan_bind_data.table);
+	for (idx_t i = 0; i < dget.names.size(); i++) {
+		auto cur_type = dget.returned_types[i];
+		if (cur_type.id() == LogicalTypeId::STRUCT) {
+			throw std::runtime_error("Structs are not yet accepted in table scans");
+		}
+		base_schema->add_names(dget.names[i]);
+		auto column_statistics = dget.function.statistics(context, &table_scan_bind_data, i);
+		bool not_null = not_null_constraint.find(i) != not_null_constraint.end();
+		auto new_type = type_info->add_types();
+		*new_type = DuckToSubstraitType(cur_type, column_statistics.get(), not_null);
+	}
+	base_schema->set_allocated_struct_(type_info);
+	sget->set_allocated_base_schema(base_schema);
 }
 
-void DuckDBToSubstrait::TransformParquetScanToSubstrait(
-    LogicalGet &dget, substrait::ReadRel *sget, BindInfo &bind_info,
-    FunctionData &bind_data) {
-  auto files_path = bind_info.GetOptionList<string>("file_path");
-  if (files_path.size() != 1) {
-    throw NotImplementedException(
-        "Substrait Parquet Reader only supports single file");
-  }
+void DuckDBToSubstrait::TransformParquetScanToSubstrait(LogicalGet &dget, substrait::ReadRel *sget, BindInfo &bind_info,
+                                                        FunctionData &bind_data) {
+	auto files_path = bind_info.GetOptionList<string>("file_path");
+	if (files_path.size() != 1) {
+		throw NotImplementedException("Substrait Parquet Reader only supports single file");
+	}
 
-  auto parquet_item = sget->mutable_local_files()->add_items();
-  // FIXME: should this be uri or file ogw
-  auto *path = new string();
-  *path = files_path[0];
-  parquet_item->set_allocated_uri_file(path);
-  parquet_item->mutable_parquet();
+	auto parquet_item = sget->mutable_local_files()->add_items();
+	// FIXME: should this be uri or file ogw
+	auto *path = new string();
+	*path = files_path[0];
+	parquet_item->set_allocated_uri_file(path);
+	parquet_item->mutable_parquet();
 
-  auto base_schema = new ::substrait::NamedStruct();
-  auto type_info = new substrait::Type_Struct();
-  type_info->set_nullability(substrait::Type_Nullability_NULLABILITY_REQUIRED);
-  for (idx_t i = 0; i < dget.names.size(); i++) {
-    auto cur_type = dget.returned_types[i];
-    if (cur_type.id() == LogicalTypeId::STRUCT) {
-      throw std::runtime_error("Structs are not yet accepted in table scans");
-    }
-    base_schema->add_names(dget.names[i]);
-    auto column_statistics = dget.function.statistics(context, &bind_data, i);
-    auto new_type = type_info->add_types();
-    *new_type = DuckToSubstraitType(cur_type, column_statistics.get(), false);
-  }
-  base_schema->set_allocated_struct_(type_info);
-  sget->set_allocated_base_schema(base_schema);
+	auto base_schema = new ::substrait::NamedStruct();
+	auto type_info = new substrait::Type_Struct();
+	type_info->set_nullability(substrait::Type_Nullability_NULLABILITY_REQUIRED);
+	for (idx_t i = 0; i < dget.names.size(); i++) {
+		auto cur_type = dget.returned_types[i];
+		if (cur_type.id() == LogicalTypeId::STRUCT) {
+			throw std::runtime_error("Structs are not yet accepted in table scans");
+		}
+		base_schema->add_names(dget.names[i]);
+		auto column_statistics = dget.function.statistics(context, &bind_data, i);
+		auto new_type = type_info->add_types();
+		*new_type = DuckToSubstraitType(cur_type, column_statistics.get(), false);
+	}
+	base_schema->set_allocated_struct_(type_info);
+	sget->set_allocated_base_schema(base_schema);
 }
 
 substrait::Rel *DuckDBToSubstrait::TransformGet(LogicalOperator &dop) {
-  auto get_rel = new substrait::Rel();
-  substrait::Rel *rel = get_rel;
-  auto &dget = (LogicalGet &)dop;
+	auto get_rel = new substrait::Rel();
+	substrait::Rel *rel = get_rel;
+	auto &dget = (LogicalGet &)dop;
 
-  if (!dget.function.get_batch_info) {
-    throw NotImplementedException(
-        "This Scanner Type can't be used in substrait because a get batch info "
-        "is not yet implemented");
-  }
-  auto bind_info = dget.function.get_batch_info(dget.bind_data.get());
-  auto sget = get_rel->mutable_read();
+	if (!dget.function.get_batch_info) {
+		throw NotImplementedException("This Scanner Type can't be used in substrait because a get batch info "
+		                              "is not yet implemented");
+	}
+	auto bind_info = dget.function.get_batch_info(dget.bind_data.get());
+	auto sget = get_rel->mutable_read();
 
-  if (!dget.table_filters.filters.empty()) {
-    // Pushdown filter
-    auto filter = CreateConjunction(
-        dget.table_filters.filters,
-        [&](std::pair<const idx_t, unique_ptr<TableFilter>> &in) {
-          auto col_idx = in.first;
-          auto return_type = dget.returned_types[col_idx];
-          auto &filter = *in.second;
-          return TransformFilter(col_idx, filter, return_type);
-        });
-    sget->set_allocated_filter(filter);
-  }
+	if (!dget.table_filters.filters.empty()) {
+		// Pushdown filter
+		auto filter =
+		    CreateConjunction(dget.table_filters.filters, [&](std::pair<const idx_t, unique_ptr<TableFilter>> &in) {
+			    auto col_idx = in.first;
+			    auto return_type = dget.returned_types[col_idx];
+			    auto &filter = *in.second;
+			    return TransformFilter(col_idx, filter, return_type);
+		    });
+		sget->set_allocated_filter(filter);
+	}
 
-  if (!dget.projection_ids.empty()) {
-    // Projection Pushdown
-    auto projection = new substrait::Expression_MaskExpression();
-    // fixme: whatever this means
-    projection->set_maintain_singular_struct(true);
-    auto select = new substrait::Expression_MaskExpression_StructSelect();
-    for (auto col_idx : dget.projection_ids) {
-      auto struct_item = select->add_struct_items();
-      struct_item->set_field((int32_t)dget.column_ids[col_idx]);
-      // FIXME do we need to set the child? if yes, to what?
-    }
-    projection->set_allocated_select(select);
-    sget->set_allocated_projection(projection);
-  }
+	if (!dget.projection_ids.empty()) {
+		// Projection Pushdown
+		auto projection = new substrait::Expression_MaskExpression();
+		// fixme: whatever this means
+		projection->set_maintain_singular_struct(true);
+		auto select = new substrait::Expression_MaskExpression_StructSelect();
+		for (auto col_idx : dget.projection_ids) {
+			auto struct_item = select->add_struct_items();
+			struct_item->set_field((int32_t)dget.column_ids[col_idx]);
+			// FIXME do we need to set the child? if yes, to what?
+		}
+		projection->set_allocated_select(select);
+		sget->set_allocated_projection(projection);
+	}
 
-  // Add Table Schema
-  switch (bind_info.type) {
-  case ScanType::TABLE:
-    TransformTableScanToSubstrait(dget, sget);
-    break;
-  case ScanType::PARQUET:
-    TransformParquetScanToSubstrait(dget, sget, bind_info, *dget.bind_data);
-    break;
-  default:
-    throw NotImplementedException(
-        "This Scan Type is not yet implement for the to_substrait function");
-  }
+	// Add Table Schema
+	switch (bind_info.type) {
+	case ScanType::TABLE:
+		TransformTableScanToSubstrait(dget, sget);
+		break;
+	case ScanType::PARQUET:
+		TransformParquetScanToSubstrait(dget, sget, bind_info, *dget.bind_data);
+		break;
+	default:
+		throw NotImplementedException("This Scan Type is not yet implement for the to_substrait function");
+	}
 
-  return rel;
+	return rel;
 }
 
 substrait::Rel *DuckDBToSubstrait::TransformCrossProduct(LogicalOperator &dop) {
-  auto rel = new substrait::Rel();
-  auto sub_cross_prod = rel->mutable_cross();
-  auto &djoin = (LogicalCrossProduct &)dop;
-  sub_cross_prod->set_allocated_left(TransformOp(*dop.children[0]));
-  sub_cross_prod->set_allocated_right(TransformOp(*dop.children[1]));
-  auto bindings = djoin.GetColumnBindings();
-  return rel;
+	auto rel = new substrait::Rel();
+	auto sub_cross_prod = rel->mutable_cross();
+	auto &djoin = (LogicalCrossProduct &)dop;
+	sub_cross_prod->set_allocated_left(TransformOp(*dop.children[0]));
+	sub_cross_prod->set_allocated_right(TransformOp(*dop.children[1]));
+	auto bindings = djoin.GetColumnBindings();
+	return rel;
 }
 
 substrait::Rel *DuckDBToSubstrait::TransformOp(LogicalOperator &dop) {
-  switch (dop.type) {
-  case LogicalOperatorType::LOGICAL_FILTER:
-    return TransformFilter(dop);
-  case LogicalOperatorType::LOGICAL_TOP_N:
-    return TransformTopN(dop);
-  case LogicalOperatorType::LOGICAL_LIMIT:
-    return TransformLimit(dop);
-  case LogicalOperatorType::LOGICAL_ORDER_BY:
-    return TransformOrderBy(dop);
-  case LogicalOperatorType::LOGICAL_PROJECTION:
-    return TransformProjection(dop);
-  case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
-    return TransformComparisonJoin(dop);
-  case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
-    return TransformAggregateGroup(dop);
-  case LogicalOperatorType::LOGICAL_GET:
-    return TransformGet(dop);
-  case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
-    return TransformCrossProduct(dop);
-  default:
-    throw InternalException(LogicalOperatorToString(dop.type));
-  }
+	switch (dop.type) {
+	case LogicalOperatorType::LOGICAL_FILTER:
+		return TransformFilter(dop);
+	case LogicalOperatorType::LOGICAL_TOP_N:
+		return TransformTopN(dop);
+	case LogicalOperatorType::LOGICAL_LIMIT:
+		return TransformLimit(dop);
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+		return TransformOrderBy(dop);
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+		return TransformProjection(dop);
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+		return TransformComparisonJoin(dop);
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		return TransformAggregateGroup(dop);
+	case LogicalOperatorType::LOGICAL_GET:
+		return TransformGet(dop);
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		return TransformCrossProduct(dop);
+	default:
+		throw InternalException(LogicalOperatorToString(dop.type));
+	}
 }
 
 substrait::RelRoot *DuckDBToSubstrait::TransformRootOp(LogicalOperator &dop) {
-  auto root_rel = new substrait::RelRoot();
-  LogicalOperator *current_op = &dop;
-  bool weird_scenario =
-      current_op->type == LogicalOperatorType::LOGICAL_PROJECTION &&
-      current_op->children[0]->type == LogicalOperatorType::LOGICAL_TOP_N;
-  if (weird_scenario) {
-    // This is a weird scenario where a projection is put on top of a top-k but
-    // the actual aliases are on the projection below the top-k still.
-    current_op = current_op->children[0].get();
-  }
-  // If the root operator is not a projection, we must go down until we find the
-  // first projection to get the aliases
-  while (current_op->type != LogicalOperatorType::LOGICAL_PROJECTION) {
-    if (current_op->children.size() != 1) {
-      throw InternalException(
-          "Root node has more than 1, or 0 children (%d) up to "
-          "reaching a projection node. Type %d",
-          current_op->children.size(), current_op->type);
-    }
-    current_op = current_op->children[0].get();
-  }
-  root_rel->set_allocated_input(TransformOp(dop));
-  auto &dproj = (LogicalProjection &)*current_op;
-  if (!weird_scenario) {
-    for (auto &expression : dproj.expressions) {
-      root_rel->add_names(expression->GetName());
-    }
-  } else {
-    for (auto &expression : dop.expressions) {
-      D_ASSERT(expression->type == ExpressionType::BOUND_REF);
-      auto b_expr = (BoundReferenceExpression *)expression.get();
-      root_rel->add_names(dproj.expressions[b_expr->index]->GetName());
-    }
-  }
+	auto root_rel = new substrait::RelRoot();
+	LogicalOperator *current_op = &dop;
+	bool weird_scenario = current_op->type == LogicalOperatorType::LOGICAL_PROJECTION &&
+	                      current_op->children[0]->type == LogicalOperatorType::LOGICAL_TOP_N;
+	if (weird_scenario) {
+		// This is a weird scenario where a projection is put on top of a top-k but
+		// the actual aliases are on the projection below the top-k still.
+		current_op = current_op->children[0].get();
+	}
+	// If the root operator is not a projection, we must go down until we find the
+	// first projection to get the aliases
+	while (current_op->type != LogicalOperatorType::LOGICAL_PROJECTION) {
+		if (current_op->children.size() != 1) {
+			throw InternalException("Root node has more than 1, or 0 children (%d) up to "
+			                        "reaching a projection node. Type %d",
+			                        current_op->children.size(), current_op->type);
+		}
+		current_op = current_op->children[0].get();
+	}
+	root_rel->set_allocated_input(TransformOp(dop));
+	auto &dproj = (LogicalProjection &)*current_op;
+	if (!weird_scenario) {
+		for (auto &expression : dproj.expressions) {
+			root_rel->add_names(expression->GetName());
+		}
+	} else {
+		for (auto &expression : dop.expressions) {
+			D_ASSERT(expression->type == ExpressionType::BOUND_REF);
+			auto b_expr = (BoundReferenceExpression *)expression.get();
+			root_rel->add_names(dproj.expressions[b_expr->index]->GetName());
+		}
+	}
 
-  return root_rel;
+	return root_rel;
 }
 
 void DuckDBToSubstrait::TransformPlan(LogicalOperator &dop) {
-  plan.add_relations()->set_allocated_root(TransformRootOp(dop));
-  auto version = plan.mutable_version();
-  version->set_major_number(0);
-  version->set_minor_number(24);
-  version->set_patch_number(0);
-  auto *producer_name = new string();
-  *producer_name = "DuckDB";
-  version->set_allocated_producer(producer_name);
+	plan.add_relations()->set_allocated_root(TransformRootOp(dop));
+	auto version = plan.mutable_version();
+	version->set_major_number(0);
+	version->set_minor_number(24);
+	version->set_patch_number(0);
+	auto *producer_name = new string();
+	*producer_name = "DuckDB";
+	version->set_allocated_producer(producer_name);
 }
 } // namespace duckdb

--- a/test/sql/test_substrait_enable_optimizer.test
+++ b/test/sql/test_substrait_enable_optimizer.test
@@ -2,101 +2,104 @@
 # description: Test conversion of DuckDB built-in function names to Substrait function names
 # group: [sql]
 
+require substrait
+
 statement ok
 PRAGMA enable_verification
 
-# statement ok
-# CREATE table ints (i INT);
+statement ok
+CREATE table ints (i INT);
 
-# statement ok
-# INSERT INTO ints VALUES (20), (8), (99), (3000);
+# All of these values are positive, so our optimizer would remove the call to abs
+statement ok
+INSERT INTO ints VALUES (20), (8), (99), (3000);
 
-# # query plan from an optimised Duckdb query plan  
-# query I
-# CALL get_substrait('SELECT abs(i) FROM ints');
-# ----
-# \x1A6\x124\x0A/:-\x12!\x0A\x1F\x12\x0D\x0A\x01i\x12\x08\x0A\x04*\x02\x10\x01\x18\x02\x22\x06\x0A\x02\x0A\x00\x10\x01:\x06\x0A\x04ints\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01i
+# query plan from an optimised Duckdb query plan  
+query I
+CALL get_substrait('SELECT abs(i) FROM ints');
+----
+\x1A6\x124\x0A/:-\x12!\x0A\x1F\x12\x0D\x0A\x01i\x12\x08\x0A\x04*\x02\x10\x01\x18\x02\x22\x06\x0A\x02\x0A\x00\x10\x01:\x06\x0A\x04ints\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01i2\x0A\x10\x18*\x06DuckDB
 
-# # query plan from an unoptimised Duckdb query plan
-# query I
-# CALL get_substrait('SELECT abs(i) FROM ints', enable_optimizer=false);
-# ----
-# \x12\x09\x1A\x07\x10\x01\x1A\x03abs\x1AA\x12?\x0A5:3\x12\x19\x0A\x17\x12\x0D\x0A\x01i\x12\x08\x0A\x04*\x02\x10\x01\x18\x02:\x06\x0A\x04ints\x1A\x16\x1A\x14\x08\x01\x1A\x04*\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x06abs(i)
+# query plan from an unoptimised Duckdb query plan
+query I
+CALL get_substrait('SELECT abs(i) FROM ints', enable_optimizer=false);
+----
+\x12\x09\x1A\x07\x10\x01\x1A\x03abs\x1AA\x12?\x0A5:3\x12\x19\x0A\x17\x12\x0D\x0A\x01i\x12\x08\x0A\x04*\x02\x10\x01\x18\x02:\x06\x0A\x04ints\x1A\x16\x1A\x14\x08\x01\x1A\x04*\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x06abs(i)2\x0A\x10\x18*\x06DuckDB
+
+# insert negative value to break optimization on all positive dataset
+statement ok
+INSERT INTO ints VALUES (-1);
+
+# with the optimized plan negative values are not set correctly
+query I
+CALL from_substrait('\x1A6\x124\x0A/:-\x12!\x0A\x1F\x12\x0D\x0A\x01i\x12\x08\x0A\x04*\x02\x10\x01\x18\x02\x22\x06\x0A\x02\x0A\x00\x10\x01:\x06\x0A\x04ints\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01i2\x0A\x10\x18*\x06DuckDB'::BLOB);
+----
+20
+8
+99
+3000
+-1
+
+# with the unoptimized plan negative values are handled correctly 
+query I
+CALL from_substrait('\x12\x09\x1A\x07\x10\x01\x1A\x03abs\x1AA\x12?\x0A5:3\x12\x19\x0A\x17\x12\x0D\x0A\x01i\x12\x08\x0A\x04*\x02\x10\x01\x18\x02:\x06\x0A\x04ints\x1A\x16\x1A\x14\x08\x01\x1A\x04*\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x06abs(i)2\x0A\x10\x18*\x06DuckDB'::BLOB);
+----
+20
+8
+99
+3000
+1
+
+statement ok
+CREATE table tbl (v varchar);
+
+statement ok
+insert into tbl VALUES('hi'), ('universe'), ('ducky');
+
+# An optimized DuckDB query plan often substitutes the LIKE operator for other operations/functions such as: equal, is_not_null, ends_with
+query I
+CALL get_substrait('select * from tbl where v LIKE ''%y''');
+----
+\x12\x0F\x1A\x0D\x10\x01\x1A\x09ends_with\x1A]\x12[\x0AV:T\x12H\x12F\x12#\x0A!\x12\x10\x0A\x01v\x12\x0B\x0A\x07\xB2\x01\x04\x08\x08\x18\x01\x18\x02\x22\x06\x0A\x02\x0A\x00\x10\x01:\x05\x0A\x03tbl\x1A\x1F\x1A\x1D\x08\x01\x1A\x04\x0A\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x22\x07\x1A\x05\x0A\x03b\x01y\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01v2\x0A\x10\x18*\x06DuckDB
+
+query I
+CALL from_substrait('\x12\x0F\x1A\x0D\x10\x01\x1A\x09ends_with\x1A]\x12[\x0AV:T\x12H\x12F\x12#\x0A!\x12\x10\x0A\x01v\x12\x0B\x0A\x07\xB2\x01\x04\x08\x08\x18\x01\x18\x02\x22\x06\x0A\x02\x0A\x00\x10\x01:\x05\x0A\x03tbl\x1A\x1F\x1A\x1D\x08\x01\x1A\x04\x0A\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x22\x07\x1A\x05\x0A\x03b\x01y\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01v2\x0A\x10\x18*\x06DuckDB'::BLOB);
+----
+ducky
+
+# If substitution is not desirable an unoptimized plan can be used instead.
+query I
+CALL get_substrait('select * from tbl where v LIKE ''%y''', enable_optimizer=false);
+----
+\x12\x0A\x1A\x08\x10\x01\x1A\x04like\x1AV\x12T\x0AO:M\x12A\x12?\x12\x1B\x0A\x19\x12\x10\x0A\x01v\x12\x0B\x0A\x07\xB2\x01\x04\x08\x08\x18\x01\x18\x02:\x05\x0A\x03tbl\x1A \x1A\x1E\x08\x01\x1A\x04\x0A\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x22\x08\x1A\x06\x0A\x04b\x02%y\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01v2\x0A\x10\x18*\x06DuckDB
+
+query I
+CALL from_substrait('\x12\x0A\x1A\x08\x10\x01\x1A\x04like\x1AV\x12T\x0AO:M\x12A\x12?\x12\x1B\x0A\x19\x12\x10\x0A\x01v\x12\x0B\x0A\x07\xB2\x01\x04\x08\x08\x18\x01\x18\x02:\x05\x0A\x03tbl\x1A \x1A\x1E\x08\x01\x1A\x04\x0A\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x22\x08\x1A\x06\x0A\x04b\x02%y\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01v2\x0A\x10\x18*\x06DuckDB'::BLOB);
+----
+ducky
+
+
+# ---------------------------- Same tests with JSON ----------------------------
+
+statement ok
+CREATE table ints_json (i INT);
+
+statement ok
+INSERT INTO ints_json VALUES (20), (8), (99), (3000);
+
+# query plan from an optimised Duckdb query plan  
+query I
+CALL get_substrait_json('SELECT abs(i) FROM ints_json');
+----
+{"relations":[{"root":{"input":{"project":{"input":{"read":{"baseSchema":{"names":["i"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"projection":{"select":{"structItems":[{}]},"maintainSingularStruct":true},"namedTable":{"names":["ints_json"]}}},"expressions":[{"selection":{"directReference":{"structField":{}},"rootReference":{}}}]}},"names":["i"]}}],"version":{"minorNumber":24,"producer":"DuckDB"}}
+
+# query plan from an unoptimised Duckdb query plan
+query I
+CALL get_substrait_json('SELECT abs(i) FROM ints_json', enable_optimizer=false);
+----
+{"extensions":[{"extensionFunction":{"functionAnchor":1,"name":"abs"}}],"relations":[{"root":{"input":{"project":{"input":{"read":{"baseSchema":{"names":["i"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"namedTable":{"names":["ints_json"]}}},"expressions":[{"scalarFunction":{"functionReference":1,"outputType":{"i32":{"nullability":"NULLABILITY_NULLABLE"}},"arguments":[{"value":{"selection":{"directReference":{"structField":{}},"rootReference":{}}}}]}}]}},"names":["abs(i)"]}}],"version":{"minorNumber":24,"producer":"DuckDB"}}
 
 # # insert negative value to break optimization on all positive dataset
-# statement ok
-# INSERT INTO ints VALUES (-1);
-
-# # with the optimized plan negative values are not set correctly
-# query I
-# CALL from_substrait('\x1A6\x124\x0A/:-\x12!\x0A\x1F\x12\x0D\x0A\x01i\x12\x08\x0A\x04*\x02\x10\x01\x18\x02\x22\x06\x0A\x02\x0A\x00\x10\x01:\x06\x0A\x04ints\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01i'::BLOB);
-# ----
-# 20
-# 8
-# 99
-# 3000
-# -1
-
-# # with the unoptimized plan negative values are handled correctly 
-# query I
-# CALL from_substrait('\x12\x09\x1A\x07\x10\x01\x1A\x03abs\x1AA\x12?\x0A5:3\x12\x19\x0A\x17\x12\x0D\x0A\x01i\x12\x08\x0A\x04*\x02\x10\x01\x18\x02:\x06\x0A\x04ints\x1A\x16\x1A\x14\x08\x01\x1A\x04*\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x06abs(i)'::BLOB);
-# ----
-# 20
-# 8
-# 99
-# 3000
-# 1
-
-# statement ok
-# CREATE table tbl (v varchar);
-
-# statement ok
-# insert into tbl VALUES('hi'), ('universe'), ('ducky');
-
-# # An optimized DuckDB query plan often substitutes the LIKE operator for other operations/functions such as: equal, is_not_null, ends_with
-# query I
-# CALL get_substrait('select * from tbl where v LIKE ''%y''');
-# ----
-# \x12\x0F\x1A\x0D\x10\x01\x1A\x09ends_with\x1A]\x12[\x0AV:T\x12H\x12F\x12#\x0A!\x12\x10\x0A\x01v\x12\x0B\x0A\x07\xB2\x01\x04\x08\x08\x18\x01\x18\x02\x22\x06\x0A\x02\x0A\x00\x10\x01:\x05\x0A\x03tbl\x1A\x1F\x1A\x1D\x08\x01\x1A\x04\x0A\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x22\x07\x1A\x05\x0A\x03b\x01y\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01v
-
-# query I
-# CALL from_substrait('\x12\x0F\x1A\x0D\x10\x01\x1A\x09ends_with\x1A]\x12[\x0AV:T\x12H\x12F\x12#\x0A!\x12\x10\x0A\x01v\x12\x0B\x0A\x07\xB2\x01\x04\x08\x08\x18\x01\x18\x02\x22\x06\x0A\x02\x0A\x00\x10\x01:\x05\x0A\x03tbl\x1A\x1F\x1A\x1D\x08\x01\x1A\x04\x0A\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x22\x07\x1A\x05\x0A\x03b\x01y\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01v'::BLOB);
-# ----
-# ducky
-
-# # If substitution is not desirable an unoptimized plan can be used instead.
-# query I
-# CALL get_substrait('select * from tbl where v LIKE ''%y''', enable_optimizer=false);
-# ----
-# \x12\x0A\x1A\x08\x10\x01\x1A\x04like\x1AV\x12T\x0AO:M\x12A\x12?\x12\x1B\x0A\x19\x12\x10\x0A\x01v\x12\x0B\x0A\x07\xB2\x01\x04\x08\x08\x18\x01\x18\x02:\x05\x0A\x03tbl\x1A \x1A\x1E\x08\x01\x1A\x04\x0A\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x22\x08\x1A\x06\x0A\x04b\x02%y\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01v
-
-# query I
-# CALL from_substrait('\x12\x0A\x1A\x08\x10\x01\x1A\x04like\x1AV\x12T\x0AO:M\x12A\x12?\x12\x1B\x0A\x19\x12\x10\x0A\x01v\x12\x0B\x0A\x07\xB2\x01\x04\x08\x08\x18\x01\x18\x02:\x05\x0A\x03tbl\x1A \x1A\x1E\x08\x01\x1A\x04\x0A\x02\x10\x01\x22\x0A\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x22\x08\x1A\x06\x0A\x04b\x02%y\x1A\x08\x12\x06\x0A\x02\x12\x00\x22\x00\x12\x01v'::BLOB);
-# ----
-# ducky
-
-
-# # ---------------------------- Same tests with JSON ----------------------------
-
-# statement ok
-# CREATE table ints_json (i INT);
-
-# statement ok
-# INSERT INTO ints_json VALUES (20), (8), (99), (3000);
-
-# # query plan from an optimised Duckdb query plan  
-# query I
-# CALL get_substrait_json('SELECT abs(i) FROM ints_json');
-# ----
-# {"relations":[{"root":{"input":{"project":{"input":{"read":{"baseSchema":{"names":["i"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"projection":{"select":{"structItems":[{}]},"maintainSingularStruct":true},"namedTable":{"names":["ints_json"]}}},"expressions":[{"selection":{"directReference":{"structField":{}},"rootReference":{}}}]}},"names":["i"]}}]}
-
-# # query plan from an unoptimised Duckdb query plan
-# query I
-# CALL get_substrait_json('SELECT abs(i) FROM ints_json', false);
-# ----
-# {"extensions":[{"extensionFunction":{"functionAnchor":1,"name":"abs"}}],"relations":[{"root":{"input":{"project":{"input":{"read":{"baseSchema":{"names":["i"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"namedTable":{"names":["ints_json"]}}},"expressions":[{"scalarFunction":{"functionReference":1,"outputType":{"i32":{"nullability":"NULLABILITY_NULLABLE"}},"arguments":[{"value":{"selection":{"directReference":{"structField":{}},"rootReference":{}}}}]}}]}},"names":["abs(i)"]}}]}
-
-# # # insert negative value to break optimization on all positive dataset
-# statement ok
-# INSERT INTO ints VALUES (-1);
+statement ok
+INSERT INTO ints VALUES (-1);
 


### PR DESCRIPTION
This PR enables tests that were previously commented out

Also added support for having the `duckdb` folder live outside of the root folder (through `DUCKDB_DIR` env var)
And fixed + ran `make format`