### PR TITLE
Fix schema mismatch crash

### DIFF
--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -692,7 +692,14 @@ SubstraitToDuckDB::TransformProjectOp(const substrait::Rel &sop,
 			if (mapping[i] < num_input_columns) {
 				expressions[i] = make_uniq<PositionalReferenceExpression>(mapping[i] + 1);
 			} else {
-				expressions[i] = TransformExpr(sop.project().expressions(mapping[i] - num_input_columns), &iterator);
+				auto expr_idx = mapping[i] - num_input_columns;
+				if (expr_idx >= (size_t)sop.project().expressions_size()) {
+					throw InvalidInputException(
+					    "Project emit mapping references expression index %d, but only %d expressions exist "
+					    "(possible schema mismatch: plan declares more columns than actual table)",
+					    expr_idx, sop.project().expressions_size());
+				}
+				expressions[i] = TransformExpr(sop.project().expressions(expr_idx), &iterator);
 			}
 		}
 	}

--- a/test/sql/test_schema_mismatch_crash.test
+++ b/test/sql/test_schema_mismatch_crash.test
@@ -1,0 +1,68 @@
+# name: test/sql/test_schema_mismatch_crash.test
+# description: Test that schema mismatch in project emit mapping raises an error instead of crashing (issue #190)
+# group: [sql]
+
+require substrait
+
+statement ok
+CREATE TABLE orders (order_id INTEGER, customer_id INTEGER, order_date VARCHAR, total DOUBLE);
+
+statement ok
+INSERT INTO orders VALUES (1, 100, '2024-01-01', 99.99), (2, 101, '2024-01-02', 149.50);
+
+# Plan declares 10 columns in baseSchema but the actual table only has 4.
+# The emit mapping [10] means: output the item at index 10, which should be
+# expression index 10 - 10 = 0 (relative to 10 declared input columns).
+# At runtime, num_input_columns = 4 (actual table), so the code computes
+# expression index 10 - 4 = 6, but only 1 expression exists -> out of bounds.
+# Before the fix this caused a segfault; after the fix it raises an error.
+statement error
+CALL from_substrait_json('{
+  "relations": [{
+    "root": {
+      "input": {
+        "project": {
+          "common": {
+            "emit": {
+              "outputMapping": [10]
+            }
+          },
+          "input": {
+            "read": {
+              "common": {"direct": {}},
+              "baseSchema": {
+                "names": ["order_id", "customer_id", "order_date", "total", "col5", "col6", "col7", "col8", "col9", "col10"],
+                "struct": {
+                  "types": [
+                    {"i32": {"nullability": "NULLABILITY_REQUIRED"}},
+                    {"i32": {"nullability": "NULLABILITY_NULLABLE"}},
+                    {"string": {"nullability": "NULLABILITY_NULLABLE"}},
+                    {"fp64": {"nullability": "NULLABILITY_NULLABLE"}},
+                    {"string": {"nullability": "NULLABILITY_NULLABLE"}},
+                    {"string": {"nullability": "NULLABILITY_NULLABLE"}},
+                    {"string": {"nullability": "NULLABILITY_NULLABLE"}},
+                    {"string": {"nullability": "NULLABILITY_NULLABLE"}},
+                    {"string": {"nullability": "NULLABILITY_NULLABLE"}},
+                    {"string": {"nullability": "NULLABILITY_NULLABLE"}}
+                  ],
+                  "nullability": "NULLABILITY_REQUIRED"
+                }
+              },
+              "namedTable": {"names": ["orders"]}
+            }
+          },
+          "expressions": [{
+            "selection": {
+              "directReference": {"structField": {"field": 3}},
+              "rootReference": {}
+            }
+          }]
+        }
+      },
+      "names": ["total"]
+    }
+  }],
+  "version": {"minorNumber": 85}
+}')
+----
+expression index


### PR DESCRIPTION
Check if `mapping[i] - num_input_columns` is a valid index.  If the substrait lists more columns than the actual table has (i.e., the schemas mismatch), this index can be invalid which leading to a segmentation fault.  This OR fixes this issue by adding a bound check and throwing an `InvalidInputException` if it fails.

Fixes: #190 