### PR TITLE
fix: column names lost in pass-through projections

### DIFF
--- a/src/include/to_substrait.hpp
+++ b/src/include/to_substrait.hpp
@@ -24,8 +24,9 @@
 namespace duckdb {
 class DuckDBToSubstrait {
 public:
-	explicit DuckDBToSubstrait(ClientContext &context, LogicalOperator &dop, bool strict_p)
-	    : context(context), strict(strict_p) {
+	explicit DuckDBToSubstrait(ClientContext &context, LogicalOperator &dop, bool strict_p,
+	                           vector<string> plan_names_p = {})
+	    : context(context), strict(strict_p), plan_names(std::move(plan_names_p)) {
 		TransformPlan(dop);
 	};
 
@@ -203,6 +204,8 @@ private:
 	//! If we are generating a query plan on strict mode we will error if
 	//! things don't go perfectly shiny
 	bool strict;
+	//! Output column names from the planner (fallback when no projection in plan)
+	vector<string> plan_names;
 	string errors;
 };
 } // namespace duckdb

--- a/src/substrait_extension.cpp
+++ b/src/substrait_extension.cpp
@@ -34,6 +34,8 @@ struct ToSubstraitFunctionData : public TableFunctionData {
 	//! We will fail the conversion on possible warnings
 	bool strict = false;
 	bool finished = false;
+	//! Output column names from the planner
+	vector<string> plan_names;
 	//! Original options from the connection
 	ClientConfig original_config;
 	set<OptimizerType> original_disabled_optimizers;
@@ -74,6 +76,7 @@ struct ToSubstraitFunctionData : public TableFunctionData {
 			planner.CreatePlan(std::move(parser.statements[0]));
 			D_ASSERT(planner.plan);
 
+			plan_names = planner.names;
 			plan = std::move(planner.plan);
 
 			if (context.config.enable_optimizer) {
@@ -209,7 +212,7 @@ static void ToSubFunctionInternal(ClientContext &context, ToSubstraitFunctionDat
                                   unique_ptr<LogicalOperator> &query_plan, string &serialized) {
 	output.SetCardinality(1);
 	query_plan = data.ExtractPlan(context);
-	auto transformer_d2s = DuckDBToSubstrait(context, *query_plan, data.strict);
+	auto transformer_d2s = DuckDBToSubstrait(context, *query_plan, data.strict, data.plan_names);
 	serialized = transformer_d2s.SerializeToString();
 	output.SetValue(0, 0, Value::BLOB_RAW(serialized));
 }
@@ -218,8 +221,7 @@ static void ToJsonFunctionInternal(ClientContext &context, ToSubstraitFunctionDa
                                    unique_ptr<LogicalOperator> &query_plan, string &serialized) {
 	output.SetCardinality(1);
 	query_plan = data.ExtractPlan(context);
-	auto transformer_d2s = DuckDBToSubstrait(context, *query_plan, data.strict);
-	;
+	auto transformer_d2s = DuckDBToSubstrait(context, *query_plan, data.strict, data.plan_names);
 	serialized = transformer_d2s.SerializeToJson();
 	output.SetValue(0, 0, serialized);
 }

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -2398,33 +2398,65 @@ substrait::RelRoot *DuckDBToSubstrait::TransformRootOp(LogicalOperator &dop) {
 	LogicalOperator *current_op = &dop;
 	bool weird_scenario = current_op->type == LogicalOperatorType::LOGICAL_PROJECTION &&
 	                      current_op->children[0]->type == LogicalOperatorType::LOGICAL_TOP_N;
-	if (weird_scenario) {
-		// This is a weird scenario where a projection is put on top of a top-k but
-		// the actual aliases are on the projection below the top-k still.
+	// Detect pass-through projection: when ORDER BY (or similar) sits between
+	// the output projection and the alias-defining projection, the top
+	// projection only contains BoundReferenceExpressions whose names are
+	// positional (#0, #1, ...). The actual aliases live in the child projection
+	// below the sort. We distinguish this from a normal column-reference
+	// projection (which also uses BoundRef but carries proper column names)
+	// by checking that ALL expressions have positional names starting with '#'.
+	bool passthrough_projection = false;
+	if (!weird_scenario && current_op->type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		auto &proj = current_op->Cast<LogicalProjection>();
+		if (!proj.expressions.empty()) {
+			passthrough_projection = true;
+			for (auto &expr : proj.expressions) {
+				if (expr->type != ExpressionType::BOUND_REF) {
+					passthrough_projection = false;
+					break;
+				}
+				auto name = expr->GetName();
+				if (name.empty() || name[0] != '#') {
+					passthrough_projection = false;
+					break;
+				}
+			}
+		}
+	}
+	if (weird_scenario || passthrough_projection) {
+		// The actual aliases are on the projection below the top-k/order/etc.
 		current_op = current_op->children[0].get();
 	}
 	// If the root operator is not a projection, we must go down until we find the
 	// first projection to get the aliases
-	while (current_op->type != LogicalOperatorType::LOGICAL_PROJECTION) {
+	bool found_projection = current_op->type == LogicalOperatorType::LOGICAL_PROJECTION;
+	while (!found_projection) {
 		if (IsSetOperation(*current_op)) {
 			// Take the projection from the first child of the set operation
 			D_ASSERT(current_op->children.size() == 2);
 			current_op = current_op->children[1].get();
-			continue;
+		} else if (current_op->children.size() != 1) {
+			break;
+		} else {
+			current_op = current_op->children[0].get();
 		}
-		if (current_op->children.size() != 1) {
-			if (current_op->type == LogicalOperatorType::LOGICAL_CREATE_TABLE) {
-				break;
-			}
-			throw InternalException("Root node has more than 1, or 0 children (%d) up to "
-			                        "reaching a projection node. Type %d",
-			                        current_op->children.size(), current_op->type);
-		}
-		current_op = current_op->children[0].get();
+		found_projection = current_op->type == LogicalOperatorType::LOGICAL_PROJECTION;
 	}
 	root_rel->set_allocated_input(TransformOp(dop));
-	auto &dproj = current_op->Cast<LogicalProjection>();
-	if (!weird_scenario) {
+	if (found_projection && (weird_scenario || passthrough_projection)) {
+		// The top projection is a pass-through (BoundRefs with #N names).
+		// Get actual aliases from the inner projection using the BoundRef indices.
+		auto &dproj = current_op->Cast<LogicalProjection>();
+		for (auto &expression : dop.expressions) {
+			auto &b_expr = expression->Cast<BoundReferenceExpression>();
+			root_rel->add_names(dproj.expressions[b_expr.index]->GetName());
+			auto depth_names = DepthFirstNames(expression->return_type);
+			for (auto &name : depth_names) {
+				root_rel->add_names(name);
+			}
+		}
+	} else if (found_projection) {
+		auto &dproj = current_op->Cast<LogicalProjection>();
 		for (auto &expression : dproj.expressions) {
 			root_rel->add_names(expression->GetName());
 			auto depth_names = DepthFirstNames(expression->return_type);
@@ -2433,13 +2465,10 @@ substrait::RelRoot *DuckDBToSubstrait::TransformRootOp(LogicalOperator &dop) {
 			}
 		}
 	} else {
-		for (auto &expression : dop.expressions) {
-			auto &b_expr = expression->Cast<BoundReferenceExpression>();
-			root_rel->add_names(dproj.expressions[b_expr.index]->GetName());
-			auto depth_names = DepthFirstNames(expression->return_type);
-			for (auto &name : depth_names) {
-				root_rel->add_names(name);
-			}
+		// No projection found in the plan tree — use the planner's output
+		// column names (set when the optimizer eliminates the projection).
+		for (auto &name : plan_names) {
+			root_rel->add_names(name);
 		}
 	}
 

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -2373,11 +2373,6 @@ substrait::Rel *DuckDBToSubstrait::TransformOp(LogicalOperator &dop) {
 	}
 }
 
-static bool IsSetOperation(const LogicalOperator &op) {
-	return op.type == LogicalOperatorType::LOGICAL_UNION || op.type == LogicalOperatorType::LOGICAL_EXCEPT ||
-	       op.type == LogicalOperatorType::LOGICAL_INTERSECT;
-}
-
 static bool IsRowModificationOperator(const LogicalOperator &op) {
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_INSERT:
@@ -2391,84 +2386,32 @@ static bool IsRowModificationOperator(const LogicalOperator &op) {
 
 substrait::RelRoot *DuckDBToSubstrait::TransformRootOp(LogicalOperator &dop) {
 	auto root_rel = new substrait::RelRoot();
+	root_rel->set_allocated_input(TransformOp(dop));
+
 	if (IsRowModificationOperator(dop)) {
-		root_rel->set_allocated_input(TransformOp(dop));
 		return root_rel;
 	}
-	LogicalOperator *current_op = &dop;
-	bool weird_scenario = current_op->type == LogicalOperatorType::LOGICAL_PROJECTION &&
-	                      current_op->children[0]->type == LogicalOperatorType::LOGICAL_TOP_N;
-	// Detect pass-through projection: when ORDER BY (or similar) sits between
-	// the output projection and the alias-defining projection, the top
-	// projection only contains BoundReferenceExpressions whose names are
-	// positional (#0, #1, ...). The actual aliases live in the child projection
-	// below the sort. We distinguish this from a normal column-reference
-	// projection (which also uses BoundRef but carries proper column names)
-	// by checking that ALL expressions have positional names starting with '#'.
-	bool passthrough_projection = false;
-	if (!weird_scenario && current_op->type == LogicalOperatorType::LOGICAL_PROJECTION) {
-		auto &proj = current_op->Cast<LogicalProjection>();
-		if (!proj.expressions.empty()) {
-			passthrough_projection = true;
-			for (auto &expr : proj.expressions) {
-				if (expr->type != ExpressionType::BOUND_REF) {
-					passthrough_projection = false;
-					break;
-				}
-				auto name = expr->GetName();
-				if (name.empty() || name[0] != '#') {
-					passthrough_projection = false;
-					break;
-				}
-			}
-		}
-	}
-	if (weird_scenario || passthrough_projection) {
-		// The actual aliases are on the projection below the top-k/order/etc.
-		current_op = current_op->children[0].get();
-	}
-	// If the root operator is not a projection, we must go down until we find the
-	// first projection to get the aliases
-	bool found_projection = current_op->type == LogicalOperatorType::LOGICAL_PROJECTION;
-	while (!found_projection) {
-		if (IsSetOperation(*current_op)) {
-			// Take the projection from the first child of the set operation
-			D_ASSERT(current_op->children.size() == 2);
-			current_op = current_op->children[1].get();
-		} else if (current_op->children.size() != 1) {
-			break;
-		} else {
-			current_op = current_op->children[0].get();
-		}
-		found_projection = current_op->type == LogicalOperatorType::LOGICAL_PROJECTION;
-	}
-	root_rel->set_allocated_input(TransformOp(dop));
-	if (found_projection && (weird_scenario || passthrough_projection)) {
-		// The top projection is a pass-through (BoundRefs with #N names).
-		// Get actual aliases from the inner projection using the BoundRef indices.
-		auto &dproj = current_op->Cast<LogicalProjection>();
-		for (auto &expression : dop.expressions) {
-			auto &b_expr = expression->Cast<BoundReferenceExpression>();
-			root_rel->add_names(dproj.expressions[b_expr.index]->GetName());
-			auto depth_names = DepthFirstNames(expression->return_type);
-			for (auto &name : depth_names) {
-				root_rel->add_names(name);
-			}
-		}
-	} else if (found_projection) {
-		auto &dproj = current_op->Cast<LogicalProjection>();
-		for (auto &expression : dproj.expressions) {
-			root_rel->add_names(expression->GetName());
-			auto depth_names = DepthFirstNames(expression->return_type);
-			for (auto &name : depth_names) {
-				root_rel->add_names(name);
+
+	if (dop.type == LogicalOperatorType::LOGICAL_CREATE_TABLE) {
+		auto &create_table = dop.Cast<LogicalCreateTable>();
+		auto &create_info = create_table.info.get()->Base();
+		auto col_names = create_info.columns.GetColumnNames();
+		auto col_types = create_info.columns.GetColumnTypes();
+		for (idx_t i = 0; i < col_names.size(); i++) {
+			root_rel->add_names(col_names[i]);
+			for (auto &sub_name : DepthFirstNames(col_types[i])) {
+				root_rel->add_names(sub_name);
 			}
 		}
 	} else {
-		// No projection found in the plan tree — use the planner's output
-		// column names (set when the optimizer eliminates the projection).
-		for (auto &name : plan_names) {
-			root_rel->add_names(name);
+		D_ASSERT(plan_names.size() == dop.types.size());
+		for (idx_t i = 0; i < plan_names.size(); i++) {
+			root_rel->add_names(plan_names[i]);
+			if (i < dop.types.size()) {
+				for (auto &sub_name : DepthFirstNames(dop.types[i])) {
+					root_rel->add_names(sub_name);
+				}
+			}
 		}
 	}
 

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(../../duckdb/src/include)
 include_directories(../../duckdb/test/include)
 include_directories(../../duckdb/third_party/catch)
 
-set(ALL_SOURCES test_substrait_c_api.cpp test_substrait_c_utils.cpp test_projection.cpp test_base_schema_projection.cpp)
+set(ALL_SOURCES test_substrait_c_api.cpp test_substrait_c_utils.cpp test_projection.cpp test_base_schema_projection.cpp test_root_names.cpp)
 
 
 add_library_unity(test_substrait OBJECT ${ALL_SOURCES})

--- a/test/c/test_root_names.cpp
+++ b/test/c/test_root_names.cpp
@@ -1,0 +1,64 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "test_substrait_c_utils.hpp"
+
+using namespace duckdb;
+using namespace std;
+
+TEST_CASE("Test root names preserved with CAST + ORDER BY", "[substrait-api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE products (product_name VARCHAR, price DECIMAL(10,2))"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO products VALUES ('Widget', 9.99), ('Gadget', 19.99)"));
+
+	// CAST + ORDER BY causes DuckDB to insert a passthrough projection with
+	// BoundReferenceExpression nodes that carry positional names (#0, #1).
+	// Root names must come from the inner projection with actual aliases.
+	auto json_str = GetSubstraitJSON(con,
+		"SELECT CAST(product_name AS VARCHAR) AS product_name, "
+		"CAST(price AS DOUBLE) AS price FROM products ORDER BY product_name");
+
+	// Root names must be the actual column aliases, not positional (#0, #1)
+	REQUIRE(json_str.find("\"names\":[\"product_name\",\"price\"]") != string::npos);
+	REQUIRE(json_str.find("\"names\":[\"#0\",\"#1\"]") == string::npos);
+}
+
+TEST_CASE("Test root names preserved with arithmetic + ORDER BY", "[substrait-api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE products (product_name VARCHAR, price DECIMAL(10,2))"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO products VALUES ('Widget', 9.99), ('Gadget', 19.99)"));
+
+	auto json_str = GetSubstraitJSON(con,
+		"SELECT product_name, price * 1.1 AS adjusted_price "
+		"FROM products ORDER BY product_name");
+
+	REQUIRE(json_str.find("\"names\":[\"product_name\",\"adjusted_price\"]") != string::npos);
+	REQUIRE(json_str.find("\"#0\"") == string::npos);
+	REQUIRE(json_str.find("\"#1\"") == string::npos);
+}
+
+TEST_CASE("Test no crash when plan has no LogicalProjection", "[substrait-api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// NOT NULL is critical: it allows the optimizer to push column selection
+	// into the scan and eliminate the LogicalProjection entirely.
+	REQUIRE_NO_FAIL(con.Query(
+		"CREATE TABLE fin_customer_risk_profile ("
+		"customer_id INTEGER NOT NULL, "
+		"risk_rating VARCHAR NOT NULL, "
+		"aml_risk_level VARCHAR NOT NULL)"));
+
+	// Without the fix, this throws:
+	// "Root node has more than 1, or 0 children (0) up to reaching a projection node. Type 30"
+	auto json_str = GetSubstraitJSON(con,
+		"SELECT customer_id, aml_risk_level FROM fin_customer_risk_profile "
+		"WHERE risk_rating = 'HIGH'");
+
+	// Should succeed and produce valid JSON with root names
+	REQUIRE(!json_str.empty());
+	REQUIRE(json_str.find("\"names\"") != string::npos);
+}

--- a/test/sql/test_no_projection_crash.test
+++ b/test/sql/test_no_projection_crash.test
@@ -1,0 +1,24 @@
+# name: test/sql/test_no_projection_crash.test
+# description: Test that get_substrait does not crash when the plan has no LogicalProjection
+# group: [sql]
+
+require substrait
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE fin_customer_risk_profile (customer_id INTEGER NOT NULL, risk_rating VARCHAR NOT NULL, aml_risk_level VARCHAR NOT NULL);
+
+# NOT NULL constraints are critical here: they allow the optimizer to
+# push column selection into the scan and eliminate the LogicalProjection
+# node entirely. Previously this caused:
+#   "Root node has more than 1, or 0 children (0) up to reaching a
+#    projection node. Type 30"
+# The fix gracefully handles plans without a projection node.
+
+statement ok
+CALL get_substrait('SELECT customer_id, aml_risk_level FROM fin_customer_risk_profile WHERE risk_rating = ''HIGH''')
+
+statement ok
+CALL get_substrait_json('SELECT customer_id, aml_risk_level FROM fin_customer_risk_profile WHERE risk_rating = ''HIGH''')


### PR DESCRIPTION
When ORDER BY (or similar operators) sit between the output projection and the alias-defining projection, DuckDB inserts a pass-through projection where all expressions are BoundReferenceExpression nodes with positional names (#0, #1, ...). TransformRootOp was not detecting this case, causing Substrait root names to contain positional placeholders instead of the actual column aliases (issue #196).

Additionally, when the optimizer eliminates LogicalProjection entirely (e.g., when NOT NULL constraints allow pushing column selection into the scan), the projection search loop threw an InternalException instead of gracefully handling the missing node (issue #197).

## Changes

**Use plan names as the primary source for output column names**: instead of walking the operator tree to find a projection and extract aliases (which failed for pass-through projections and missing projections), use `plan_names`, the same authoritative names DuckDB computes a priori for SQL output headers.

**Handle CTAS separately**: for CREATE TABLE AS, the planner sets `plan_names = ["Count"]` (DDL semantics), so column names are taken directly from `CreateInfo.columns` instead.

**Remove tree-walking heuristics**: `IsSetOperation`, the `weird_scenario` flag, the while-loop descending through the tree, and the `InternalException` for unknown tree shapes are all eliminated.

**Tests**: add C API tests for CAST+ORDER BY, arithmetic+ORDER BY, and no-projection scenarios; add a SQL test for the no-projection crash.