### PR TITLE
fix: operator type vectors stale/inconsistent with actual column bindings

### DIFF
--- a/src/substrait_extension.cpp
+++ b/src/substrait_extension.cpp
@@ -81,6 +81,7 @@ struct ToSubstraitFunctionData : public TableFunctionData {
 				plan = optimizer.Optimize(std::move(plan));
 			}
 
+			plan->ResolveOperatorTypes();
 			ColumnBindingResolver resolver;
 			ColumnBindingResolver::Verify(*plan);
 			resolver.VisitOperator(*plan);

--- a/test/sql/test_groupby_having_order.test
+++ b/test/sql/test_groupby_having_order.test
@@ -1,0 +1,27 @@
+# name: test/sql/test_groupby_having_order.test
+# description: Test get_substrait with JOIN + GROUP BY + HAVING + ORDER BY on aggregate alias
+# group: [sql]
+
+require substrait
+
+statement ok
+CREATE TABLE customers (customer_id INTEGER NOT NULL, first_name VARCHAR NOT NULL, last_name VARCHAR NOT NULL, email VARCHAR NOT NULL);
+
+statement ok
+CREATE TABLE orders (order_id INTEGER NOT NULL, customer_id INTEGER NOT NULL);
+
+statement ok
+INSERT INTO customers VALUES (1, 'Alice', 'Smith', 'alice@example.com'), (2, 'Bob', 'Jones', 'bob@example.com');
+
+statement ok
+INSERT INTO orders VALUES (1, 1), (2, 1), (3, 1), (4, 1), (5, 2);
+
+# JOIN + GROUP BY + HAVING + ORDER BY on aggregate alias triggers:
+#   "Failed to bind column reference "customer_id" [0.0]:
+#    inequal num bindings/types (6 != 5)"
+
+statement ok
+CALL get_substrait('SELECT c.customer_id, c.first_name, c.last_name, c.email, COUNT(o.order_id) AS order_count FROM customers c JOIN orders o ON c.customer_id = o.customer_id GROUP BY c.customer_id, c.first_name, c.last_name, c.email HAVING COUNT(o.order_id) > 3 ORDER BY order_count DESC')
+
+statement ok
+CALL get_substrait_json('SELECT c.customer_id, c.first_name, c.last_name, c.email, COUNT(o.order_id) AS order_count FROM customers c JOIN orders o ON c.customer_id = o.customer_id GROUP BY c.customer_id, c.first_name, c.last_name, c.email HAVING COUNT(o.order_id) > 3 ORDER BY order_count DESC')


### PR DESCRIPTION
After the optimizer reshapes the logical plan, operator type vectors (`op.types`) can become stale or inconsistent with the actual column bindings. When `ColumnBindingResolver` then attempts to resolve references, it encounters a mismatch between binding count and type count, causing a "Failed to bind column reference: inequal num bindings/types" error.

This surfaces with queries that combine JOIN + GROUP BY + HAVING + ORDER BY on an aggregate alias, where the optimizer's transformations leave a type/binding discrepancy.

Call `plan->ResolveOperatorTypes()` after optimization and before `ColumnBindingResolver` runs, ensuring operator types are recomputed bottom-up to reflect the optimized tree structure.

Fixes: #199 