### PR TITLE
fix: bind local file reads to baseSchema by name

### DIFF
--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -1015,15 +1015,18 @@ shared_ptr<Relation> SubstraitToDuckDB::TransformReadOp(const substrait::Rel &so
 		throw NotImplementedException("Unsupported type of read operator for substrait");
 	}
 
-	// When a named table's physical schema has more columns than the plan's
-	// baseSchema declares, add a projection to narrow down to only the declared
-	// columns. Without this, downstream emit mappings (which assume baseSchema
-	// column count) compute wrong expression indices.
-	if (sget.has_named_table() && sget.has_base_schema() && !sget.has_projection()) {
+	// Align the scan's physical columns to the plan's baseSchema by name.
+	// Named tables only need this when the physical schema is wider. Local file
+	// scans always need it because Parquet columns are otherwise bound in physical
+	// file order, while baseSchema defines the ReadRel tuple's order.
+	if ((sget.has_named_table() || sget.has_local_files()) && sget.has_base_schema() &&
+	    !sget.has_projection()) {
 		auto &base_schema = sget.base_schema();
 		auto physical_cols = scan->Columns().size();
 		auto declared_cols = (size_t)base_schema.names_size();
-		if (declared_cols > 0 && declared_cols < physical_cols) {
+		bool needs_projection = sget.has_local_files() ? declared_cols > 0
+		                                               : declared_cols > 0 && declared_cols < physical_cols;
+		if (needs_projection) {
 			// Match baseSchema column names to physical column positions
 			vector<unique_ptr<ParsedExpression>> proj_exprs;
 			vector<string> proj_aliases;

--- a/test/sql/test_local_files_base_schema.test
+++ b/test/sql/test_local_files_base_schema.test
@@ -1,0 +1,18 @@
+# name: test/sql/test_local_files_base_schema.test
+# description: Test that local file reads follow baseSchema column selection and order
+# group: [sql]
+
+require substrait
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+# The Parquet file starts with l_orderkey, while baseSchema both prunes the file
+# and requests l_discount before l_orderkey.
+query RI
+CALL from_substrait_json('{"relations":[{"root":{"input":{"fetch":{"input":{"read":{"baseSchema":{"names":["l_discount","l_orderkey"],"struct":{"types":[{"fp64":{"nullability":"NULLABILITY_NULLABLE"}},{"i64":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"localFiles":{"items":[{"uriFile":"data/parquet-testing/lineitem-top10000.gzip.parquet","parquet":{}}]}}},"offset":"0","count":"3"}},"names":["l_discount","l_orderkey"]}}],"version":{"minorNumber":89,"producer":"test"}}')
+----
+0.04	1
+0.09	1
+0.1	1


### PR DESCRIPTION
## Problem

`from_substrait` currently exposes Parquet columns from a `ReadRel.localFiles`
scan in their physical file order.

A Substrait `ReadRel`'s `baseSchema` defines the columns and ordering visible to
downstream expressions. When `baseSchema` prunes or reorders Parquet columns,
field references are instead evaluated against the physical Parquet layout.
This can return the wrong columns without reporting an error.

Named-table reads already project wider physical schemas onto `baseSchema` by
name.

## Change

Apply the same name-based alignment to `localFiles` reads:

- Project the Parquet scan onto the columns declared by `baseSchema`.
- Preserve the order declared by `baseSchema`.
- Report the existing schema-mismatch error when a declared column is absent.

Local-file reads are projected whenever they have a non-empty `baseSchema`,
since matching column counts do not guarantee matching column order.

## Test

Add a regression test using the existing TPC-H Parquet fixture. The physical
file starts with `l_orderkey`, while the plan requests the pruned and reordered
schema `[l_discount, l_orderkey]`.

The test verifies that the returned values follow the `baseSchema` order.

Local validation:

- `git diff --check` passes.
- Full local compilation was not available because CMake is not installed in
  the development environment; the new SQLLogicTest is intended to run in CI.
