### PR TITLE
fix: disable hive partition inference for Substrait local files

### DIFF
--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -906,7 +906,10 @@ shared_ptr<Relation> SubstraitToDuckDB::TransformReadOp(const substrait::Rel &so
 			}
 		}
 		string name = "parquet_" + StringUtil::GenerateRandomName();
-		named_parameter_map_t named_parameters({{"binary_as_string", Value::BOOLEAN(false)}});
+		// A ReadRel baseSchema describes the complete output tuple. Do not let
+		// key=value path segments implicitly add hive partition columns to it.
+		named_parameter_map_t named_parameters(
+		    {{"binary_as_string", Value::BOOLEAN(false)}, {"hive_partitioning", Value::BOOLEAN(false)}});
 		vector<Value> parameters {Value::LIST(parquet_files)};
 		shared_ptr<TableFunctionRelation> scan_rel;
 		if (acquire_lock) {

--- a/test/sql/test_local_files_hive_partitioning.test
+++ b/test/sql/test_local_files_hive_partitioning.test
@@ -1,0 +1,25 @@
+# name: test/sql/test_local_files_hive_partitioning.test
+# description: Test that local file paths do not add implicit hive partition columns
+# group: [sql]
+
+require substrait
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE hive_source(partition_key INTEGER, value VARCHAR)
+
+statement ok
+INSERT INTO hive_source VALUES (42, 'answer')
+
+# The partition key is encoded only in the key=value directory and is not part
+# of the Parquet file. It must not be appended to the ReadRel output tuple.
+statement ok
+COPY hive_source TO '__TEST_DIR__/local_files_hive' (FORMAT PARQUET, PARTITION_BY (partition_key))
+
+query T
+CALL from_substrait_json('{"relations":[{"root":{"input":{"read":{"baseSchema":{"names":["value"],"struct":{"types":[{"string":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"localFiles":{"items":[{"uriFile":"__TEST_DIR__/local_files_hive/**/*.parquet","parquet":{}}]}}},"names":["value"]}}],"version":{"minorNumber":89,"producer":"test"}}')
+----
+answer


### PR DESCRIPTION
## Problem

DuckDB's `parquet_scan` automatically detects hive-style `key=value` path
segments and appends them as columns.

For a Substrait `ReadRel.localFiles` scan, `baseSchema` defines the complete
output tuple. Automatically adding path-derived columns changes its width and
field positions, potentially causing schema mismatches or incorrect downstream
field references.

The Substrait plan does not request hive partition discovery, so deriving extra
columns from the path is engine-specific behavior.

## Change

Pass `hive_partitioning = false` when creating the `parquet_scan` used by
`from_substrait`.

This keeps the scan output limited to the physical Parquet columns described by
the plan's `baseSchema`.

## Test

Add a regression test that:

1. Writes a Parquet dataset partitioned into a `partition_key=42` directory.
2. Reads the generated file through `ReadRel.localFiles`.
3. Declares only the physical `value` column in `baseSchema`.
4. Verifies that the path-derived partition key is not appended to the result.

The underlying behavior was also verified directly: the default Parquet scan
returns `value, partition_key`, while `hive_partitioning = false` returns only
`value`.

Local validation:

- `git diff --check` passes.
- Full local compilation was not available because CMake is not installed in
  the development environment; the new SQLLogicTest is intended to run in CI.
