### PR TITLE
build: update to Substrait v0.90.0

### DIFF
--- a/scripts/generate_custom_functions.py
+++ b/scripts/generate_custom_functions.py
@@ -13,7 +13,7 @@ import regex
 # version, then re-run this script and commit the regenerated
 # src/custom_extensions_generated.cpp.
 SUBSTRAIT_PACKAGING_REPO = "https://github.com/substrait-io/substrait-packaging.git"
-SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.89.0"
+SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.90.0"
 SUBSTRAIT_EXTENSIONS_SUBDIR = os.path.join("cpp", "substrait-extensions", "extensions")
 
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -4,7 +4,7 @@
             "kind": "git",
             "repository": "https://github.com/substrait-io/substrait-packaging",
             "reference": "vcpkg-registry",
-            "baseline": "4d6660bdfda1df81ded6602012b98fa80f3a7d54",
+            "baseline": "d71abd164b43306c70dbcee1c33858c74dee9717",
             "packages": [
                 "substrait-protobuf",
                 "substrait-extensions",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,7 @@
     "overrides": [
         {
             "name": "substrait-protobuf",
-            "version": "0.89.0"
+            "version": "0.90.0"
         }
     ]
 }


### PR DESCRIPTION
Closes #215.

Updates the extension from Substrait **v0.89.0** to **v0.90.0**. Since #210 migrated the Substrait dependencies to the `substrait-packaging` vcpkg registry, the upgrade is the coupled version bump documented in `renovate.json`:

- **`vcpkg.json`**: `substrait-protobuf` override `0.89.0` → `0.90.0`
- **`vcpkg-configuration.json`**: `substrait-packaging` vcpkg-registry baseline → `d71abd164b43306c70dbcee1c33858c74dee9717` (the commit that published `substrait-protobuf` 0.90.0 and `substrait-extensions` 0.90.0)
- **`scripts/generate_custom_functions.py`**: `SUBSTRAIT_EXTENSIONS_TAG` → `cpp/substrait-extensions/v0.90.0`

The `builtin-baseline` in `vcpkg.json` is intentionally left unchanged (it stays pinned to DuckDB's `vcpkg_commit`).

### No code changes required

- The `algebra.proto` delta between 0.89.0 and 0.90.0 is **doc-comment only** (`ExtensionSingleRel`/`ExtensionLeafRel`/`ExtensionMultiRel`) — no field, enum, or wire-format changes.
- The extension definition YAMLs are **identical** between 0.89.0 and 0.90.0, so regenerating produces no change to `src/custom_extensions_generated.cpp`.
- The [v0.90.0](https://github.com/substrait-io/substrait/releases/tag/v0.90.0) spec changes — the nullability-binding vs. any-type-parameter clarification (#960) and the unquoted typed temporal test literals fix (#1064) — don't touch anything this extension implements.

### Verification

- Reran the custom-functions codegen against the v0.90.0 extensions → `src/custom_extensions_generated.cpp` unchanged.
- `make release` builds successfully; vcpkg resolves `substrait-protobuf` 0.90.0 against the new registry baseline.
- SQL test suite passes: **All tests passed (1 skipped, 1268 assertions in 48 test cases)**.

🤖 Generated with AI
