### PR TITLE
feat: convert duplicate eliminated joins (DELIM_JOIN/DELIM_GET) to Substrait

### DIFF
--- a/src/include/to_substrait.hpp
+++ b/src/include/to_substrait.hpp
@@ -64,6 +64,7 @@ private:
 	substrait::Rel *TransformLimit(LogicalOperator &dop);
 	substrait::Rel *TransformOrderBy(LogicalOperator &dop);
 	substrait::Rel *TransformComparisonJoin(LogicalOperator &dop);
+	substrait::Rel *TransformDuplicateEliminatedGet(LogicalOperator &dop);
 	substrait::Rel *TransformAggregateGroup(LogicalOperator &dop);
 	substrait::Rel *TransformWindow(LogicalOperator &dop);
 	substrait::Rel *TransformExpressionGet(LogicalOperator &dop);
@@ -79,6 +80,9 @@ private:
 	substrait::Rel *TransformDeleteTable(LogicalOperator &dop);
 	substrait::Rel *TransformCTERef(LogicalOperator &dop);
 	static vector<LogicalType>::size_type GetColumnCount(LogicalOperator &dop);
+	//! Returns the RelCommon of the concrete relation held by rel, or nullptr for
+	//! relation types that are never produced by this transformer.
+	static substrait::RelCommon *GetRelCommon(substrait::Rel &rel);
 	static substrait::Rel *TransformDummyScan();
 	substrait::Rel *TransformEmptyResult(LogicalOperator &dop);
 	static substrait::RelCommon *CreateOutputMapping(vector<int32_t> vector);
@@ -184,6 +188,23 @@ private:
 		}
 		return res;
 	}
+
+	//! State of an enclosing duplicate eliminated join (LOGICAL_DELIM_JOIN) that is needed
+	//! to expand the duplicate eliminated get scans (LOGICAL_DELIM_GET) within it.
+	struct DuplicateEliminationSource {
+		//! The child of the join whose duplicate eliminated column values feed the gets.
+		LogicalOperator *data_side;
+		//! Positions of the duplicate eliminated columns within the data side's output.
+		vector<idx_t> column_indices;
+		//! Plan-unique identifier tying the saved computation hint on the join's data side
+		//! to the loaded computation hints on the copies emitted for its gets.
+		int32_t computation_id;
+	};
+	//! The duplicate eliminated joins enclosing the operator currently being transformed,
+	//! innermost last.
+	vector<DuplicateEliminationSource> duplicate_elimination_sources;
+	//! Last plan-unique computation id handed out for saved/loaded computation hints.
+	int32_t last_computation_id = 0;
 
 	//! Variables used to register functions
 	unordered_map<string, uint64_t> functions_map;

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -1169,12 +1169,52 @@ substrait::Rel *DuckDBToSubstrait::TransformComparisonJoin(LogicalOperator &dop)
 	bool is_right_semi = djoin.join_type == JoinType::RIGHT_SEMI;
 	idx_t left_child_idx = is_right_semi ? 1 : 0;
 	idx_t right_child_idx = is_right_semi ? 0 : 1;
-	
-	sjoin->set_allocated_left(TransformOp(*dop.children[left_child_idx]));
-	sjoin->set_allocated_right(TransformOp(*dop.children[right_child_idx]));
+
+	// A duplicate eliminated join (what DuckDB abbreviates as a delim join) is a comparison
+	// join that additionally feeds the distinct values of some of its data side's columns
+	// (the duplicate eliminated columns) into duplicate eliminated get scans
+	// (LOGICAL_DELIM_GET) within its other child. Substrait has no equivalent construct, so
+	// each of those scans is expanded into an aggregation over a copy of the data side (see
+	// TransformDuplicateEliminatedGet). The data side is registered here while the scan side
+	// is transformed, and marked as a saved computation so consumers can recognize that the
+	// copies (marked as loaded computations) do not need to be computed again.
+	bool is_duplicate_eliminated = dop.type == LogicalOperatorType::LOGICAL_DELIM_JOIN;
+	idx_t data_side_idx = djoin.delim_flipped ? 1 : 0;
+	int32_t computation_id = is_duplicate_eliminated ? ++last_computation_id : 0;
+	auto transform_child = [&](idx_t child_idx) -> substrait::Rel * {
+		if (!is_duplicate_eliminated) {
+			return TransformOp(*dop.children[child_idx]);
+		}
+		if (child_idx == data_side_idx) {
+			auto data_side = TransformOp(*dop.children[child_idx]);
+			auto common = GetRelCommon(*data_side);
+			if (common) {
+				auto saved = common->mutable_hint()->add_saved_computations();
+				saved->set_computation_id(computation_id);
+				saved->set_type(substrait::RelCommon_Hint_ComputationType_COMPUTATION_TYPE_UNKNOWN);
+			}
+			return data_side;
+		}
+		DuplicateEliminationSource source;
+		source.data_side = dop.children[data_side_idx].get();
+		for (auto &dexpr : djoin.duplicate_eliminated_columns) {
+			if (dexpr->GetExpressionType() != ExpressionType::BOUND_REF) {
+				throw NotImplementedException("Duplicate eliminated column must be a bound reference");
+			}
+			source.column_indices.push_back(dexpr->Cast<BoundReferenceExpression>().index);
+		}
+		source.computation_id = computation_id;
+		duplicate_elimination_sources.push_back(std::move(source));
+		auto scan_side = TransformOp(*dop.children[child_idx]);
+		duplicate_elimination_sources.pop_back();
+		return scan_side;
+	};
+	sjoin->set_allocated_left(transform_child(left_child_idx));
+	sjoin->set_allocated_right(transform_child(right_child_idx));
 
 	auto left_col_count = dop.children[left_child_idx]->types.size();
-	if (dop.children[left_child_idx]->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+	if (dop.children[left_child_idx]->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
+	    dop.children[left_child_idx]->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
 		auto &child_join = dop.children[left_child_idx]->Cast<LogicalComparisonJoin>();
 		if (child_join.join_type != JoinType::SEMI && child_join.join_type != JoinType::ANTI && child_join.join_type != JoinType::RIGHT_SEMI) {
 			left_col_count = child_join.left_projection_map.size() + child_join.right_projection_map.size();
@@ -1314,6 +1354,47 @@ substrait::Rel *DuckDBToSubstrait::TransformComparisonJoin(LogicalOperator &dop)
 	projection->set_allocated_common(rel_common);
 	projection->set_allocated_input(res);
 	return proj_rel;
+}
+
+substrait::Rel *DuckDBToSubstrait::TransformDuplicateEliminatedGet(LogicalOperator &dop) {
+	auto &dget = dop.Cast<LogicalDelimGet>();
+	if (duplicate_elimination_sources.empty()) {
+		throw NotImplementedException("Found a duplicate eliminated get without an enclosing "
+		                              "duplicate eliminated join");
+	}
+	// A duplicate eliminated get scans the distinct values of the duplicate eliminated
+	// columns of its innermost enclosing duplicate eliminated join. Substrait has no
+	// equivalent construct, so emit a copy of the join's data side aggregated on those
+	// columns, which produces exactly the rows the get scans.
+	auto source = duplicate_elimination_sources.back();
+	if (source.column_indices.size() != dget.chunk_types.size()) {
+		throw InternalException("Duplicate eliminated get scans %llu columns but the enclosing "
+		                        "duplicate eliminated join eliminates duplicates over %llu columns",
+		                        dget.chunk_types.size(), source.column_indices.size());
+	}
+	// The data side may itself contain duplicate eliminated gets, but they belong to outer
+	// duplicate eliminated joins; hide this join's entry while the copy is emitted so they
+	// resolve against the correct join.
+	duplicate_elimination_sources.pop_back();
+	auto data_side = TransformOp(*source.data_side);
+	duplicate_elimination_sources.push_back(source);
+	// Mark the copy as a load of the computation saved on the join's data side.
+	auto common = GetRelCommon(*data_side);
+	if (common) {
+		auto loaded = common->mutable_hint()->add_loaded_computations();
+		loaded->set_computation_id_reference(source.computation_id);
+		loaded->set_type(substrait::RelCommon_Hint_ComputationType_COMPUTATION_TYPE_UNKNOWN);
+	}
+
+	auto res = new substrait::Rel();
+	auto aggregate = res->mutable_aggregate();
+	aggregate->set_allocated_input(data_side);
+	auto grouping = aggregate->add_groupings();
+	for (idx_t i = 0; i < source.column_indices.size(); i++) {
+		CreateFieldRef(aggregate->add_grouping_expressions(), source.column_indices[i]);
+		grouping->add_expression_references(i);
+	}
+	return res;
 }
 
 substrait::Rel *DuckDBToSubstrait::TransformAggregateGroup(LogicalOperator &dop) {
@@ -2441,6 +2522,33 @@ vector<LogicalType>::size_type DuckDBToSubstrait::GetColumnCount(LogicalOperator
 	return dop.types.size();
 }
 
+substrait::RelCommon *DuckDBToSubstrait::GetRelCommon(substrait::Rel &rel) {
+	switch (rel.rel_type_case()) {
+	case substrait::Rel::RelTypeCase::kRead:
+		return rel.mutable_read()->mutable_common();
+	case substrait::Rel::RelTypeCase::kFilter:
+		return rel.mutable_filter()->mutable_common();
+	case substrait::Rel::RelTypeCase::kFetch:
+		return rel.mutable_fetch()->mutable_common();
+	case substrait::Rel::RelTypeCase::kAggregate:
+		return rel.mutable_aggregate()->mutable_common();
+	case substrait::Rel::RelTypeCase::kSort:
+		return rel.mutable_sort()->mutable_common();
+	case substrait::Rel::RelTypeCase::kJoin:
+		return rel.mutable_join()->mutable_common();
+	case substrait::Rel::RelTypeCase::kProject:
+		return rel.mutable_project()->mutable_common();
+	case substrait::Rel::RelTypeCase::kSet:
+		return rel.mutable_set()->mutable_common();
+	case substrait::Rel::RelTypeCase::kCross:
+		return rel.mutable_cross()->mutable_common();
+	case substrait::Rel::RelTypeCase::kWindow:
+		return rel.mutable_window()->mutable_common();
+	default:
+		return nullptr;
+	}
+}
+
 substrait::Rel *DuckDBToSubstrait::TransformOp(LogicalOperator &dop) {
 	switch (dop.type) {
 	case LogicalOperatorType::LOGICAL_FILTER:
@@ -2455,6 +2563,12 @@ substrait::Rel *DuckDBToSubstrait::TransformOp(LogicalOperator &dop) {
 		return TransformProjection(dop);
 	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
 		return TransformComparisonJoin(dop);
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+		// A duplicate eliminated join is a comparison join with extra bookkeeping for the
+		// duplicate eliminated get scans it feeds; TransformComparisonJoin handles both.
+		return TransformComparisonJoin(dop);
+	case LogicalOperatorType::LOGICAL_DELIM_GET:
+		return TransformDuplicateEliminatedGet(dop);
 	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
 		return TransformAggregateGroup(dop);
 	case LogicalOperatorType::LOGICAL_WINDOW:

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -1191,7 +1191,7 @@ substrait::Rel *DuckDBToSubstrait::TransformComparisonJoin(LogicalOperator &dop)
 			if (common) {
 				auto saved = common->mutable_hint()->add_saved_computations();
 				saved->set_computation_id(computation_id);
-				saved->set_type(substrait::RelCommon_Hint_ComputationType_COMPUTATION_TYPE_UNKNOWN);
+				saved->set_type(substrait::RelCommon_Hint_ComputationType_COMPUTATION_TYPE_HASHTABLE);
 			}
 			return data_side;
 		}
@@ -1383,7 +1383,7 @@ substrait::Rel *DuckDBToSubstrait::TransformDuplicateEliminatedGet(LogicalOperat
 	if (common) {
 		auto loaded = common->mutable_hint()->add_loaded_computations();
 		loaded->set_computation_id_reference(source.computation_id);
-		loaded->set_type(substrait::RelCommon_Hint_ComputationType_COMPUTATION_TYPE_UNKNOWN);
+		loaded->set_type(substrait::RelCommon_Hint_ComputationType_COMPUTATION_TYPE_HASHTABLE);
 	}
 
 	auto res = new substrait::Rel();

--- a/test/sql/test_substrait_duplicate_eliminated_join.test
+++ b/test/sql/test_substrait_duplicate_eliminated_join.test
@@ -1,0 +1,53 @@
+# name: test/sql/test_substrait_duplicate_eliminated_join.test
+# description: Test round-tripping of duplicate eliminated joins (DELIM_JOIN/DELIM_GET)
+# group: [sql]
+
+require substrait
+
+statement ok
+CREATE TABLE sales (store_sk INTEGER, customer_sk INTEGER, category VARCHAR, amount DECIMAL(7,2));
+
+# Key values deliberately exceed 1000 to catch placeholder implementations that
+# only cover small key domains.
+statement ok
+INSERT INTO sales VALUES
+    (5001, 9001, 'apparel', 100.00),
+    (5001, 9002, 'apparel', 300.00),
+    (5001, 9003, 'shoes', 250.00),
+    (5002, 9001, 'shoes', 80.00),
+    (5002, 9004, 'apparel', 120.00),
+    (5003, 9005, 'garden', 500.00),
+    (5003, NULL, 'garden', 500.00);
+
+statement ok
+CREATE TABLE stores (store_sk INTEGER, state VARCHAR);
+
+statement ok
+INSERT INTO stores VALUES (5001, 'TN'), (5002, 'CA'), (5003, 'TN');
+
+# The expanded duplicate eliminated gets are tied to the join's data side with
+# saved/loaded computation hints. This runs before enable_verification because
+# selecting from get_substrait_json is unrelated to round-tripping.
+query I
+SELECT "Json" LIKE '%savedComputations%' AND "Json" LIKE '%loadedComputations%' FROM get_substrait_json('WITH totals AS (SELECT store_sk, customer_sk, Sum(amount) AS total FROM sales GROUP BY store_sk, customer_sk) SELECT t1.customer_sk FROM totals t1, stores WHERE t1.total > (SELECT Avg(total) * 1.2 FROM totals t2 WHERE t1.store_sk = t2.store_sk) AND stores.store_sk = t1.store_sk AND stores.state = ''TN'' ORDER BY t1.customer_sk');
+----
+true
+
+statement ok
+PRAGMA enable_verification
+
+# Correlated aggregate over a grouped common table expression referenced twice
+# (the pattern of TPC-DS Q1): the duplicate eliminated join survives the
+# optimizer, correlating on an integer key.
+statement ok
+CALL get_substrait('WITH totals AS (SELECT store_sk, customer_sk, Sum(amount) AS total FROM sales GROUP BY store_sk, customer_sk) SELECT t1.customer_sk FROM totals t1, stores WHERE t1.total > (SELECT Avg(total) * 1.2 FROM totals t2 WHERE t1.store_sk = t2.store_sk) AND stores.store_sk = t1.store_sk AND stores.state = ''TN'' ORDER BY t1.customer_sk');
+
+# The same pattern correlating on a VARCHAR key: the duplicate eliminated
+# columns are not integers.
+statement ok
+CALL get_substrait('WITH totals AS (SELECT category, store_sk, customer_sk, Sum(amount) AS total FROM sales GROUP BY category, store_sk, customer_sk) SELECT t1.customer_sk FROM totals t1, stores WHERE t1.total > (SELECT Avg(total) * 1.2 FROM totals t2 WHERE t1.category = t2.category) AND stores.store_sk = t1.store_sk AND stores.state = ''TN'' ORDER BY t1.customer_sk');
+
+# Correlated EXISTS combined with OR (the pattern of TPC-DS Q10), which keeps
+# duplicate eliminated mark joins.
+statement ok
+CALL get_substrait('SELECT category FROM sales s1 WHERE EXISTS (SELECT * FROM sales s2 WHERE s1.customer_sk = s2.customer_sk AND s2.amount > 90) AND (EXISTS (SELECT * FROM sales s3 WHERE s1.customer_sk = s3.customer_sk AND s3.category = ''shoes'') OR EXISTS (SELECT * FROM sales s4 WHERE s1.customer_sk = s4.customer_sk AND s4.category = ''garden'')) ORDER BY category');

--- a/test/sql/test_substrait_tpcds.test
+++ b/test/sql/test_substrait_tpcds.test
@@ -12,11 +12,9 @@ PRAGMA enable_verification
 statement ok
 CALL dsdgen(sf=0.1)
 
-#Q 1 (DELIM_JOIN)
-statement error
+#Q 1
+statement ok
 CALL get_substrait('WITH customer_total_return AS (SELECT sr_customer_sk AS ctr_customer_sk, sr_store_sk AS ctr_store_sk, Sum(sr_return_amt) AS ctr_total_return FROM store_returns, date_dim WHERE sr_returned_date_sk = d_date_sk AND d_year = 2001 GROUP BY sr_customer_sk, sr_store_sk) SELECT c_customer_id FROM customer_total_return ctr1, store, customer WHERE ctr1.ctr_total_return > (SELECT Avg(ctr_total_return) * 1.2 FROM customer_total_return ctr2 WHERE ctr1.ctr_store_sk = ctr2.ctr_store_sk) AND s_store_sk = ctr1.ctr_store_sk AND s_state = ''TN'' AND ctr1.ctr_customer_sk = c_customer_sk ORDER BY c_customer_id LIMIT 100; ')
-----
-Not implemented Error: DELIM_JOIN
 
 #Q 2 (results dont match)
 #statement ok
@@ -34,11 +32,9 @@ CALL get_substrait('WITH year_total AS (SELECT c_customer_id customer_id, c_firs
 statement ok
 CALL get_substrait('WITH ssr AS ( SELECT s_store_id, Sum(sales_price) AS sales, Sum(profit) AS profit, Sum(return_amt) AS returns1, Sum(net_loss) AS profit_loss FROM ( SELECT ss_store_sk AS store_sk, ss_sold_date_sk AS date_sk, ss_ext_sales_price AS sales_price, ss_net_profit AS profit, Cast(0 AS DECIMAL(7,2)) AS return_amt, Cast(0 AS DECIMAL(7,2)) AS net_loss FROM store_sales UNION ALL SELECT sr_store_sk AS store_sk, sr_returned_date_sk AS date_sk, Cast(0 AS DECIMAL(7,2)) AS sales_price, Cast(0 AS DECIMAL(7,2)) AS profit, sr_return_amt AS return_amt, sr_net_loss AS net_loss FROM store_returns ) salesreturns, date_dim, store WHERE date_sk = d_date_sk AND d_date BETWEEN Cast(''2002-08-22'' AS DATE) AND ( Cast(''2002-08-22'' AS DATE) + INTERVAL ''14'' day) AND store_sk = s_store_sk GROUP BY s_store_id) , csr AS ( SELECT cp_catalog_page_id, sum(sales_price) AS sales, sum(profit) AS profit, sum(return_amt) AS returns1, sum(net_loss) AS profit_loss FROM ( SELECT cs_catalog_page_sk AS page_sk, cs_sold_date_sk AS date_sk, cs_ext_sales_price AS sales_price, cs_net_profit AS profit, cast(0 AS decimal(7,2)) AS return_amt, cast(0 AS decimal(7,2)) AS net_loss FROM catalog_sales UNION ALL SELECT cr_catalog_page_sk AS page_sk, cr_returned_date_sk AS date_sk, cast(0 AS decimal(7,2)) AS sales_price, cast(0 AS decimal(7,2)) AS profit, cr_return_amount AS return_amt, cr_net_loss AS net_loss FROM catalog_returns ) salesreturns, date_dim, catalog_page WHERE date_sk = d_date_sk AND d_date BETWEEN cast(''2002-08-22'' AS date) AND ( cast(''2002-08-22'' AS date) + INTERVAL ''14'' day) AND page_sk = cp_catalog_page_sk GROUP BY cp_catalog_page_id) , wsr AS ( SELECT web_site_id, sum(sales_price) AS sales, sum(profit) AS profit, sum(return_amt) AS returns1, sum(net_loss) AS profit_loss FROM ( SELECT ws_web_site_sk AS wsr_web_site_sk, ws_sold_date_sk AS date_sk, ws_ext_sales_price AS sales_price, ws_net_profit AS profit, cast(0 AS decimal(7,2)) AS return_amt, cast(0 AS decimal(7,2)) AS net_loss FROM web_sales UNION ALL SELECT ws_web_site_sk AS wsr_web_site_sk, wr_returned_date_sk AS date_sk, cast(0 AS decimal(7,2)) AS sales_price, cast(0 AS decimal(7,2)) AS profit, wr_return_amt AS return_amt, wr_net_loss AS net_loss FROM web_returns LEFT OUTER JOIN web_sales ON ( wr_item_sk = ws_item_sk AND wr_order_number = ws_order_number) ) salesreturns, date_dim, web_site WHERE date_sk = d_date_sk AND d_date BETWEEN cast(''2002-08-22'' AS date) AND ( cast(''2002-08-22'' AS date) + INTERVAL ''14'' day) AND wsr_web_site_sk = web_site_sk GROUP BY web_site_id) SELECT channel , id , sum(sales) AS sales , sum(returns1) AS returns1 , sum(profit) AS profit FROM ( SELECT ''store channel'' AS channel , ''store'' || s_store_id AS id , sales , returns1 , (profit - profit_loss) AS profit FROM ssr UNION ALL SELECT ''catalog channel'' AS channel , ''catalog_page'' || cp_catalog_page_id AS id , sales , returns1 , (profit - profit_loss) AS profit FROM csr UNION ALL SELECT ''web channel'' AS channel , ''web_site'' || web_site_id AS id , sales , returns1 , (profit - profit_loss) AS profit FROM wsr ) x GROUP BY rollup (channel, id) ORDER BY channel , id LIMIT 100; ')
 
-#Q 6 (DELIM_JOIN)
-statement error
+#Q 6
+statement ok
 CALL get_substrait('SELECT a.ca_state state, Count(*) cnt FROM customer_address a, customer c, store_sales s, date_dim d, item i WHERE a.ca_address_sk = c.c_current_addr_sk AND c.c_customer_sk = s.ss_customer_sk AND s.ss_sold_date_sk = d.d_date_sk AND s.ss_item_sk = i.i_item_sk AND d.d_month_seq = (SELECT DISTINCT ( d_month_seq ) FROM date_dim WHERE d_year = 1998 AND d_moy = 7) AND i.i_current_price > 1.2 * (SELECT Avg(j.i_current_price) FROM item j WHERE j.i_category = i.i_category) GROUP BY a.ca_state HAVING Count(*) >= 10 ORDER BY cnt LIMIT 100; ')
-----
-Not implemented Error: DELIM_JOIN
 
 #Q 7
 statement ok
@@ -52,11 +48,9 @@ CALL get_substrait('SELECT s_store_name, Sum(ss_net_profit) FROM store_sales, da
 statement ok
 CALL get_substrait('SELECT CASE WHEN (SELECT Count(*) FROM store_sales WHERE ss_quantity BETWEEN 1 AND 20) > 3672 THEN (SELECT Avg(ss_ext_list_price) FROM store_sales WHERE ss_quantity BETWEEN 1 AND 20) ELSE (SELECT Avg(ss_net_profit) FROM store_sales WHERE ss_quantity BETWEEN 1 AND 20) END bucket1, CASE WHEN (SELECT Count(*) FROM store_sales WHERE ss_quantity BETWEEN 21 AND 40) > 3392 THEN (SELECT Avg(ss_ext_list_price) FROM store_sales WHERE ss_quantity BETWEEN 21 AND 40) ELSE (SELECT Avg(ss_net_profit) FROM store_sales WHERE ss_quantity BETWEEN 21 AND 40) END bucket2, CASE WHEN (SELECT Count(*) FROM store_sales WHERE ss_quantity BETWEEN 41 AND 60) > 32784 THEN (SELECT Avg(ss_ext_list_price) FROM store_sales WHERE ss_quantity BETWEEN 41 AND 60) ELSE (SELECT Avg(ss_net_profit) FROM store_sales WHERE ss_quantity BETWEEN 41 AND 60) END bucket3, CASE WHEN (SELECT Count(*) FROM store_sales WHERE ss_quantity BETWEEN 61 AND 80) > 26032 THEN (SELECT Avg(ss_ext_list_price) FROM store_sales WHERE ss_quantity BETWEEN 61 AND 80) ELSE (SELECT Avg(ss_net_profit) FROM store_sales WHERE ss_quantity BETWEEN 61 AND 80) END bucket4, CASE WHEN (SELECT Count(*) FROM store_sales WHERE ss_quantity BETWEEN 81 AND 100) > 23982 THEN (SELECT Avg(ss_ext_list_price) FROM store_sales WHERE ss_quantity BETWEEN 81 AND 100) ELSE (SELECT Avg(ss_net_profit) FROM store_sales WHERE ss_quantity BETWEEN 81 AND 100) END bucket5 FROM reason WHERE r_reason_sk = 1; ')
 
-#Q 10 (DELIM_JOIN)
-statement error
+#Q 10
+statement ok
 CALL get_substrait('SELECT cd_gender, cd_marital_status, cd_education_status, Count(*) cnt1, cd_purchase_estimate, Count(*) cnt2, cd_credit_rating, Count(*) cnt3, cd_dep_count, Count(*) cnt4, cd_dep_employed_count, Count(*) cnt5, cd_dep_college_count, Count(*) cnt6 FROM customer c, customer_address ca, customer_demographics WHERE c.c_current_addr_sk = ca.ca_address_sk AND ca_county IN ( ''Lycoming County'', ''Sheridan County'', ''Kandiyohi County'', ''Pike County'', ''Greene County'' ) AND cd_demo_sk = c.c_current_cdemo_sk AND EXISTS (SELECT * FROM store_sales, date_dim WHERE c.c_customer_sk = ss_customer_sk AND ss_sold_date_sk = d_date_sk AND d_year = 2002 AND d_moy BETWEEN 4 AND 4 + 3) AND ( EXISTS (SELECT * FROM web_sales, date_dim WHERE c.c_customer_sk = ws_bill_customer_sk AND ws_sold_date_sk = d_date_sk AND d_year = 2002 AND d_moy BETWEEN 4 AND 4 + 3) OR EXISTS (SELECT * FROM catalog_sales, date_dim WHERE c.c_customer_sk = cs_ship_customer_sk AND cs_sold_date_sk = d_date_sk AND d_year = 2002 AND d_moy BETWEEN 4 AND 4 + 3) ) GROUP BY cd_gender, cd_marital_status, cd_education_status, cd_purchase_estimate, cd_credit_rating, cd_dep_count, cd_dep_employed_count, cd_dep_college_count ORDER BY cd_gender, cd_marital_status, cd_education_status, cd_purchase_estimate, cd_credit_rating, cd_dep_count, cd_dep_employed_count, cd_dep_college_count LIMIT 100; ')
-----
-Not implemented Error: DELIM_JOIN
 
 #Q 11
 statement ok
@@ -78,11 +72,11 @@ CALL get_substrait('SELECT Avg(ss_quantity), Avg(ss_ext_sales_price), Avg(ss_ext
 statement ok
 CALL get_substrait('SELECT ca_zip, Sum(cs_sales_price) FROM catalog_sales, customer, customer_address, date_dim WHERE cs_bill_customer_sk = c_customer_sk AND c_current_addr_sk = ca_address_sk AND ( Substr(ca_zip, 1, 5) IN ( ''85669'', ''86197'', ''88274'', ''83405'', ''86475'', ''85392'', ''85460'', ''80348'', ''81792'' ) OR ca_state IN ( ''CA'', ''WA'', ''GA'' ) OR cs_sales_price > 500 ) AND cs_sold_date_sk = d_date_sk AND d_qoy = 1 AND d_year = 1998 GROUP BY ca_zip ORDER BY ca_zip LIMIT 100; ')
 
-#Q 16 (DELIM_JOIN)
+#Q 16 (RIGHT_ANTI)
 statement error
 CALL get_substrait('SELECT Count(DISTINCT cs_order_number) AS "order count" , Sum(cs_ext_ship_cost) AS "total shipping cost" , Sum(cs_net_profit) AS "total net profit" FROM catalog_sales cs1 , date_dim , customer_address , call_center WHERE d_date BETWEEN ''2002-3-01'' AND ( Cast(''2002-3-01'' AS DATE) + INTERVAL ''60'' day) AND cs1.cs_ship_date_sk = d_date_sk AND cs1.cs_ship_addr_sk = ca_address_sk AND ca_state = ''IA'' AND cs1.cs_call_center_sk = cc_call_center_sk AND cc_county IN (''Williamson County'', ''Williamson County'', ''Williamson County'', ''Williamson County'', ''Williamson County'' ) AND EXISTS ( SELECT * FROM catalog_sales cs2 WHERE cs1.cs_order_number = cs2.cs_order_number AND cs1.cs_warehouse_sk <> cs2.cs_warehouse_sk) AND NOT EXISTS ( SELECT * FROM catalog_returns cr1 WHERE cs1.cs_order_number = cr1.cr_order_number) ORDER BY count(DISTINCT cs_order_number) LIMIT 100; ')
 ----
-Not implemented Error: DELIM_JOIN
+Not implemented Error: Unsupported join type RIGHT_ANTI
 
 #Q 17 
 statement ok
@@ -147,11 +141,9 @@ Binder Error: Referenced column "c_last_review_date" not found in FROM clause!
 statement ok
 CALL get_substrait('WITH ss AS (SELECT ca_county, d_qoy, d_year, Sum(ss_ext_sales_price) AS store_sales FROM store_sales, date_dim, customer_address WHERE ss_sold_date_sk = d_date_sk AND ss_addr_sk = ca_address_sk GROUP BY ca_county, d_qoy, d_year), ws AS (SELECT ca_county, d_qoy, d_year, Sum(ws_ext_sales_price) AS web_sales FROM web_sales, date_dim, customer_address WHERE ws_sold_date_sk = d_date_sk AND ws_bill_addr_sk = ca_address_sk GROUP BY ca_county, d_qoy, d_year) SELECT ss1.ca_county, ss1.d_year, ws2.web_sales / ws1.web_sales web_q1_q2_increase, ss2.store_sales / ss1.store_sales store_q1_q2_increase, ws3.web_sales / ws2.web_sales web_q2_q3_increase, ss3.store_sales / ss2.store_sales store_q2_q3_increase FROM ss ss1, ss ss2, ss ss3, ws ws1, ws ws2, ws ws3 WHERE ss1.d_qoy = 1 AND ss1.d_year = 2001 AND ss1.ca_county = ss2.ca_county AND ss2.d_qoy = 2 AND ss2.d_year = 2001 AND ss2.ca_county = ss3.ca_county AND ss3.d_qoy = 3 AND ss3.d_year = 2001 AND ss1.ca_county = ws1.ca_county AND ws1.d_qoy = 1 AND ws1.d_year = 2001 AND ws1.ca_county = ws2.ca_county AND ws2.d_qoy = 2 AND ws2.d_year = 2001 AND ws1.ca_county = ws3.ca_county AND ws3.d_qoy = 3 AND ws3.d_year = 2001 AND CASE WHEN ws1.web_sales > 0 THEN ws2.web_sales / ws1.web_sales ELSE NULL END > CASE WHEN ss1.store_sales > 0 THEN ss2.store_sales / ss1.store_sales ELSE NULL END AND CASE WHEN ws2.web_sales > 0 THEN ws3.web_sales / ws2.web_sales ELSE NULL END > CASE WHEN ss2.store_sales > 0 THEN ss3.store_sales / ss2.store_sales ELSE NULL END ORDER BY ss1.d_year; ')
 
-#Q 32 (DELIM_JOIN)
-statement error
+#Q 32
+statement ok
 CALL get_substrait('SELECT Sum(cs_ext_discount_amt) AS "excess discount amount" FROM catalog_sales , item , date_dim WHERE i_manufact_id = 610 AND i_item_sk = cs_item_sk AND d_date BETWEEN ''2001-03-04'' AND ( Cast(''2001-03-04'' AS DATE) + INTERVAL ''90'' day) AND d_date_sk = cs_sold_date_sk AND cs_ext_discount_amt > ( SELECT 1.3 * avg(cs_ext_discount_amt) FROM catalog_sales , date_dim WHERE cs_item_sk = i_item_sk AND d_date BETWEEN ''2001-03-04'' AND ( cast(''2001-03-04'' AS date) + INTERVAL ''90'' day) AND d_date_sk = cs_sold_date_sk ) LIMIT 100; ')
-----
-Not implemented Error: DELIM_JOIN
 
 #Q 33
 statement ok
@@ -161,11 +153,9 @@ CALL get_substrait('WITH ss AS (SELECT i_manufact_id, Sum(ss_ext_sales_price) to
 statement ok
 CALL get_substrait('SELECT c_last_name, c_first_name, c_salutation, c_preferred_cust_flag, ss_ticket_number, cnt FROM (SELECT ss_ticket_number, ss_customer_sk, Count(*) cnt FROM store_sales, date_dim, store, household_demographics WHERE store_sales.ss_sold_date_sk = date_dim.d_date_sk AND store_sales.ss_store_sk = store.s_store_sk AND store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk AND ( date_dim.d_dom BETWEEN 1 AND 3 OR date_dim.d_dom BETWEEN 25 AND 28 ) AND ( household_demographics.hd_buy_potential = ''>10000'' OR household_demographics.hd_buy_potential = ''unknown'' ) AND household_demographics.hd_vehicle_count > 0 AND ( CASE WHEN household_demographics.hd_vehicle_count > 0 THEN household_demographics.hd_dep_count / household_demographics.hd_vehicle_count ELSE NULL END ) > 1.2 AND date_dim.d_year IN ( 1999, 1999 + 1, 1999 + 2 ) AND store.s_county IN ( ''Williamson County'', ''Williamson County'', ''Williamson County'', ''Williamson County'' , ''Williamson County'', ''Williamson County'', ''Williamson County'', ''Williamson County'' ) GROUP BY ss_ticket_number, ss_customer_sk) dn, customer WHERE ss_customer_sk = c_customer_sk AND cnt BETWEEN 15 AND 20 ORDER BY c_last_name, c_first_name, c_salutation, c_preferred_cust_flag DESC; ')
 
-#Q 35 (DELIM_JOIN)
-statement error
+#Q 35
+statement ok
 CALL get_substrait('SELECT ca_state, cd_gender, cd_marital_status, cd_dep_count, Count(*) cnt1, Stddev_samp(cd_dep_count), Avg(cd_dep_count), Max(cd_dep_count), cd_dep_employed_count, Count(*) cnt2, Stddev_samp(cd_dep_employed_count), Avg(cd_dep_employed_count), Max(cd_dep_employed_count), cd_dep_college_count, Count(*) cnt3, Stddev_samp(cd_dep_college_count), Avg(cd_dep_college_count), Max(cd_dep_college_count) FROM customer c, customer_address ca, customer_demographics WHERE c.c_current_addr_sk = ca.ca_address_sk AND cd_demo_sk = c.c_current_cdemo_sk AND EXISTS (SELECT * FROM store_sales, date_dim WHERE c.c_customer_sk = ss_customer_sk AND ss_sold_date_sk = d_date_sk AND d_year = 2001 AND d_qoy < 4) AND ( EXISTS (SELECT * FROM web_sales, date_dim WHERE c.c_customer_sk = ws_bill_customer_sk AND ws_sold_date_sk = d_date_sk AND d_year = 2001 AND d_qoy < 4) OR EXISTS (SELECT * FROM catalog_sales, date_dim WHERE c.c_customer_sk = cs_ship_customer_sk AND cs_sold_date_sk = d_date_sk AND d_year = 2001 AND d_qoy < 4) ) GROUP BY ca_state, cd_gender, cd_marital_status, cd_dep_count, cd_dep_employed_count, cd_dep_college_count ORDER BY ca_state, cd_gender, cd_marital_status, cd_dep_count, cd_dep_employed_count, cd_dep_college_count LIMIT 100; ')
-----
-Not implemented Error: DELIM_JOIN
 
 #Q 36
 statement ok
@@ -188,10 +178,8 @@ statement ok
 CALL get_substrait('SELECT w_state , i_item_id , Sum( CASE WHEN ( Cast(d_date AS DATE) < Cast (''2002-06-01'' AS DATE)) THEN cs_sales_price - COALESCE(cr_refunded_cash,0) ELSE 0 END) AS sales_before , Sum( CASE WHEN ( Cast(d_date AS DATE) >= Cast (''2002-06-01'' AS DATE)) THEN cs_sales_price - COALESCE(cr_refunded_cash,0) ELSE 0 END) AS sales_after FROM catalog_sales LEFT OUTER JOIN catalog_returns ON ( cs_order_number = cr_order_number AND cs_item_sk = cr_item_sk) , warehouse , item , date_dim WHERE i_current_price BETWEEN 0.99 AND 1.49 AND i_item_sk = cs_item_sk AND cs_warehouse_sk = w_warehouse_sk AND cs_sold_date_sk = d_date_sk AND d_date BETWEEN (Cast (''2002-06-01'' AS DATE) - INTERVAL ''30'' day) AND ( cast (''2002-06-01'' AS date) + INTERVAL ''30'' day) GROUP BY w_state, i_item_id ORDER BY w_state, i_item_id LIMIT 100; ')
 
 #Q 41
-statement error
+statement ok
 CALL get_substrait('SELECT Distinct(i_product_name) FROM item i1 WHERE i_manufact_id BETWEEN 765 AND 765 + 40 AND (SELECT Count(*) AS item_cnt FROM item WHERE ( i_manufact = i1.i_manufact AND ( ( i_category = ''Women'' AND ( i_color = ''dim'' OR i_color = ''green'' ) AND ( i_units = ''Gross'' OR i_units = ''Dozen'' ) AND ( i_size = ''economy'' OR i_size = ''petite'' ) ) OR ( i_category = ''Women'' AND ( i_color = ''navajo'' OR i_color = ''aquamarine'' ) AND ( i_units = ''Case'' OR i_units = ''Unknown'' ) AND ( i_size = ''large'' OR i_size = ''N/A'' ) ) OR ( i_category = ''Men'' AND ( i_color = ''indian'' OR i_color = ''dark'' ) AND ( i_units = ''Oz'' OR i_units = ''Lb'' ) AND ( i_size = ''extra large'' OR i_size = ''small'' ) ) OR ( i_category = ''Men'' AND ( i_color = ''peach'' OR i_color = ''purple'' ) AND ( i_units = ''Tbl'' OR i_units = ''Bunch'' ) AND ( i_size = ''economy'' OR i_size = ''petite'' ) ) ) ) OR ( i_manufact = i1.i_manufact AND ( ( i_category = ''Women'' AND ( i_color = ''orchid'' OR i_color = ''peru'' ) AND ( i_units = ''Carton'' OR i_units = ''Cup'' ) AND ( i_size = ''economy'' OR i_size = ''petite'' ) ) OR ( i_category = ''Women'' AND ( i_color = ''violet'' OR i_color = ''papaya'' ) AND ( i_units = ''Ounce'' OR i_units = ''Box'' ) AND ( i_size = ''large'' OR i_size = ''N/A'' ) ) OR ( i_category = ''Men'' AND ( i_color = ''drab'' OR i_color = ''grey'' ) AND ( i_units = ''Each'' OR i_units = ''N/A'' ) AND ( i_size = ''extra large'' OR i_size = ''small'' ) ) OR ( i_category = ''Men'' AND ( i_color = ''chocolate'' OR i_color = ''antique'' ) AND ( i_units = ''Dram'' OR i_units = ''Gram'' ) AND ( i_size = ''economy'' OR i_size = ''petite'' ) ) ) )) > 0 ORDER BY i_product_name LIMIT 100; ')
-----
-Not implemented Error: DELIM_JOIN
 
 #Q 42
 statement ok
@@ -305,11 +293,11 @@ Parser Error: syntax error at or near "100"
 statement ok
 CALL get_substrait('SELECT c_last_name, c_first_name, ca_city, bought_city, ss_ticket_number, extended_price, extended_tax, list_price FROM (SELECT ss_ticket_number, ss_customer_sk, ca_city bought_city, Sum(ss_ext_sales_price) extended_price, Sum(ss_ext_list_price) list_price, Sum(ss_ext_tax) extended_tax FROM store_sales, date_dim, store, household_demographics, customer_address WHERE store_sales.ss_sold_date_sk = date_dim.d_date_sk AND store_sales.ss_store_sk = store.s_store_sk AND store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk AND store_sales.ss_addr_sk = customer_address.ca_address_sk AND date_dim.d_dom BETWEEN 1 AND 2 AND ( household_demographics.hd_dep_count = 8 OR household_demographics.hd_vehicle_count = 3 ) AND date_dim.d_year IN ( 1998, 1998 + 1, 1998 + 2 ) AND store.s_city IN ( ''Fairview'', ''Midway'' ) GROUP BY ss_ticket_number, ss_customer_sk, ss_addr_sk, ca_city) dn, customer, customer_address current_addr WHERE ss_customer_sk = c_customer_sk AND customer.c_current_addr_sk = current_addr.ca_address_sk AND current_addr.ca_city <> bought_city ORDER BY c_last_name, ss_ticket_number LIMIT 100; ')
 
-#Q 69 (DELIM_JOIN)
+#Q 69 (ANTI)
 statement error
 CALL get_substrait('SELECT cd_gender, cd_marital_status, cd_education_status, Count(*) cnt1, cd_purchase_estimate, Count(*) cnt2, cd_credit_rating, Count(*) cnt3 FROM customer c, customer_address ca, customer_demographics WHERE c.c_current_addr_sk = ca.ca_address_sk AND ca_state IN ( ''KS'', ''AZ'', ''NE'' ) AND cd_demo_sk = c.c_current_cdemo_sk AND EXISTS (SELECT * FROM store_sales, date_dim WHERE c.c_customer_sk = ss_customer_sk AND ss_sold_date_sk = d_date_sk AND d_year = 2004 AND d_moy BETWEEN 3 AND 3 + 2) AND ( NOT EXISTS (SELECT * FROM web_sales, date_dim WHERE c.c_customer_sk = ws_bill_customer_sk AND ws_sold_date_sk = d_date_sk AND d_year = 2004 AND d_moy BETWEEN 3 AND 3 + 2) AND NOT EXISTS (SELECT * FROM catalog_sales, date_dim WHERE c.c_customer_sk = cs_ship_customer_sk AND cs_sold_date_sk = d_date_sk AND d_year = 2004 AND d_moy BETWEEN 3 AND 3 + 2) ) GROUP BY cd_gender, cd_marital_status, cd_education_status, cd_purchase_estimate, cd_credit_rating ORDER BY cd_gender, cd_marital_status, cd_education_status, cd_purchase_estimate, cd_credit_rating LIMIT 100; ')
 ----
-Not implemented Error: DELIM_JOIN
+Not implemented Error: Unsupported join type ANTI
 
 #Q 70
 statement ok
@@ -355,11 +343,9 @@ CALL get_substrait('SELECT c_last_name, c_first_name, Substr(s_city, 1, 30), ss_
 statement ok
 CALL get_substrait('WITH ssr AS ( SELECT s_store_id AS store_id, Sum(ss_ext_sales_price) AS sales, Sum(COALESCE(sr_return_amt, 0)) AS returns1, Sum(ss_net_profit - COALESCE(sr_net_loss, 0)) AS profit FROM store_sales LEFT OUTER JOIN store_returns ON ( ss_item_sk = sr_item_sk AND ss_ticket_number = sr_ticket_number), date_dim, store, item, promotion WHERE ss_sold_date_sk = d_date_sk AND d_date BETWEEN Cast(''2000-08-26'' AS DATE) AND ( Cast(''2000-08-26'' AS DATE) + INTERVAL ''30'' day) AND ss_store_sk = s_store_sk AND ss_item_sk = i_item_sk AND i_current_price > 50 AND ss_promo_sk = p_promo_sk AND p_channel_tv = ''N'' GROUP BY s_store_id) , csr AS ( SELECT cp_catalog_page_id AS catalog_page_id, sum(cs_ext_sales_price) AS sales, sum(COALESCE(cr_return_amount, 0)) AS returns1, sum(cs_net_profit - COALESCE(cr_net_loss, 0)) AS profit FROM catalog_sales LEFT OUTER JOIN catalog_returns ON ( cs_item_sk = cr_item_sk AND cs_order_number = cr_order_number), date_dim, catalog_page, item, promotion WHERE cs_sold_date_sk = d_date_sk AND d_date BETWEEN cast(''2000-08-26'' AS date) AND ( cast(''2000-08-26'' AS date) + INTERVAL ''30'' day) AND cs_catalog_page_sk = cp_catalog_page_sk AND cs_item_sk = i_item_sk AND i_current_price > 50 AND cs_promo_sk = p_promo_sk AND p_channel_tv = ''N'' GROUP BY cp_catalog_page_id) , wsr AS ( SELECT web_site_id, sum(ws_ext_sales_price) AS sales, sum(COALESCE(wr_return_amt, 0)) AS returns1, sum(ws_net_profit - COALESCE(wr_net_loss, 0)) AS profit FROM web_sales LEFT OUTER JOIN web_returns ON ( ws_item_sk = wr_item_sk AND ws_order_number = wr_order_number), date_dim, web_site, item, promotion WHERE ws_sold_date_sk = d_date_sk AND d_date BETWEEN cast(''2000-08-26'' AS date) AND ( cast(''2000-08-26'' AS date) + INTERVAL ''30'' day) AND ws_web_site_sk = web_site_sk AND ws_item_sk = i_item_sk AND i_current_price > 50 AND ws_promo_sk = p_promo_sk AND p_channel_tv = ''N'' GROUP BY web_site_id) SELECT channel , id , sum(sales) AS sales , sum(returns1) AS returns1 , sum(profit) AS profit FROM ( SELECT ''store channel'' AS channel , ''store'' || store_id AS id , sales , returns1 , profit FROM ssr UNION ALL SELECT ''catalog channel'' AS channel , ''catalog_page'' || catalog_page_id AS id , sales , returns1 , profit FROM csr UNION ALL SELECT ''web channel'' AS channel , ''web_site'' || web_site_id AS id , sales , returns1 , profit FROM wsr ) x GROUP BY rollup (channel, id) ORDER BY channel , id LIMIT 100; ')
 
-#Q 81 (DELIM_JOIN)
-statement error
+#Q 81
+statement ok
 CALL get_substrait(' WITH customer_total_return AS (SELECT cr_returning_customer_sk AS ctr_customer_sk, ca_state AS ctr_state, Sum(cr_return_amt_inc_tax) AS ctr_total_return FROM catalog_returns, date_dim, customer_address WHERE cr_returned_date_sk = d_date_sk AND d_year = 1999 AND cr_returning_addr_sk = ca_address_sk GROUP BY cr_returning_customer_sk, ca_state) SELECT c_customer_id, c_salutation, c_first_name, c_last_name, ca_street_number, ca_street_name, ca_street_type, ca_suite_number, ca_city, ca_county, ca_state, ca_zip, ca_country, ca_gmt_offset, ca_location_type, ctr_total_return FROM customer_total_return ctr1, customer_address, customer WHERE ctr1.ctr_total_return > (SELECT Avg(ctr_total_return) * 1.2 FROM customer_total_return ctr2 WHERE ctr1.ctr_state = ctr2.ctr_state) AND ca_address_sk = c_current_addr_sk AND ca_state = ''TX'' AND ctr1.ctr_customer_sk = c_customer_sk ORDER BY c_customer_id, c_salutation, c_first_name, c_last_name, ca_street_number, ca_street_name, ca_street_type, ca_suite_number, ca_city, ca_county, ca_state, ca_zip, ca_country, ca_gmt_offset, ca_location_type, ctr_total_return LIMIT 100; ')
-----
-Not implemented Error: DELIM_JOIN
 
 #Q 82
 statement ok
@@ -401,21 +387,19 @@ CALL get_substrait(' SELECT Cast(amc AS DECIMAL(15, 4)) / Cast(pmc AS DECIMAL(15
 statement ok
 CALL get_substrait('SELECT cc_call_center_id Call_Center, cc_name Call_Center_Name, cc_manager Manager, Sum(cr_net_loss) Returns_Loss FROM call_center, catalog_returns, date_dim, customer, customer_address, customer_demographics, household_demographics WHERE cr_call_center_sk = cc_call_center_sk AND cr_returned_date_sk = d_date_sk AND cr_returning_customer_sk = c_customer_sk AND cd_demo_sk = c_current_cdemo_sk AND hd_demo_sk = c_current_hdemo_sk AND ca_address_sk = c_current_addr_sk AND d_year = 1999 AND d_moy = 12 AND ( ( cd_marital_status = ''M'' AND cd_education_status = ''Unknown'' ) OR ( cd_marital_status = ''W'' AND cd_education_status = ''Advanced Degree'' ) ) AND hd_buy_potential LIKE ''Unknown%'' AND ca_gmt_offset = -7 GROUP BY cc_call_center_id, cc_name, cc_manager, cd_marital_status, cd_education_status ORDER BY Sum(cr_net_loss) DESC; ')
 
-#Q 92 (DELIM_JOIN)
-statement error
+#Q 92
+statement ok
 CALL get_substrait('SELECT Sum(ws_ext_discount_amt) AS "Excess Discount Amount" FROM web_sales , item , date_dim WHERE i_manufact_id = 718 AND i_item_sk = ws_item_sk AND d_date BETWEEN ''2002-03-29'' AND ( Cast(''2002-03-29'' AS DATE) + INTERVAL ''90'' day) AND d_date_sk = ws_sold_date_sk AND ws_ext_discount_amt > ( SELECT 1.3 * avg(ws_ext_discount_amt) FROM web_sales , date_dim WHERE ws_item_sk = i_item_sk AND d_date BETWEEN ''2002-03-29'' AND ( cast(''2002-03-29'' AS date) + INTERVAL ''90'' day) AND d_date_sk = ws_sold_date_sk ) ORDER BY sum(ws_ext_discount_amt) LIMIT 100; ')
-----
-Not implemented Error: DELIM_JOIN
 
 #Q 93
 statement ok
 CALL get_substrait('SELECT ss_customer_sk, Sum(act_sales) sumsales FROM (SELECT ss_item_sk, ss_ticket_number, ss_customer_sk, CASE WHEN sr_return_quantity IS NOT NULL THEN ( ss_quantity - sr_return_quantity ) * ss_sales_price ELSE ( ss_quantity * ss_sales_price ) END act_sales FROM store_sales LEFT OUTER JOIN store_returns ON ( sr_item_sk = ss_item_sk AND sr_ticket_number = ss_ticket_number ), reason WHERE sr_reason_sk = r_reason_sk AND r_reason_desc = ''reason 38'') t GROUP BY ss_customer_sk ORDER BY sumsales, ss_customer_sk LIMIT 100; ')
 
-#Q 94 (DELIM_JOIN)
+#Q 94 (RIGHT_ANTI)
 statement error
 CALL get_substrait('SELECT Count(DISTINCT ws_order_number) AS "order count" , Sum(ws_ext_ship_cost) AS "total shipping cost" , Sum(ws_net_profit) AS "total net profit" FROM web_sales ws1 , date_dim , customer_address , web_site WHERE d_date BETWEEN ''2000-3-01'' AND ( Cast(''2000-3-01'' AS DATE) + INTERVAL ''60'' day) AND ws1.ws_ship_date_sk = d_date_sk AND ws1.ws_ship_addr_sk = ca_address_sk AND ca_state = ''MT'' AND ws1.ws_web_site_sk = web_site_sk AND web_company_name = ''pri'' AND EXISTS ( SELECT * FROM web_sales ws2 WHERE ws1.ws_order_number = ws2.ws_order_number AND ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk) AND NOT EXISTS ( SELECT * FROM web_returns wr1 WHERE ws1.ws_order_number = wr1.wr_order_number) ORDER BY count(DISTINCT ws_order_number) LIMIT 100; ')
 ----
-Not implemented Error: DELIM_JOIN
+Not implemented Error: Unsupported join type RIGHT_ANTI
 
 #Q 95
 statement ok

--- a/test/sql/test_substrait_tpch.test
+++ b/test/sql/test_substrait_tpch.test
@@ -2,11 +2,10 @@
 # description: Test get_substrait with TPC-H queries
 # group: [sql]
 
-# test skipped since PR https://github.com/duckdb/duckdb/pull/9993
-# the PR re-introduces DelimJoins in TPC-H again for performance reasons
-# if there is a selection in the duplicate-eliminated side, we keep the DelimJoin
-# this is checked in Deliminator::HasSelection
-# if this function returns false, all DelimJoins are removed from TPC-H
+# Duplicate eliminated joins (DELIM_JOIN) survive the optimizer in several of
+# these queries since https://github.com/duckdb/duckdb/pull/9993 and are
+# converted to Substrait via the expansion in TransformDuplicateEliminatedGet.
+# Q21 and Q22 remain blocked on the ANTI/RIGHT_ANTI join type gap.
 
 require substrait
 
@@ -22,17 +21,17 @@ CALL dbgen(sf=0.01)
 statement ok
 CALL get_substrait('SELECT l_returnflag, l_linestatus, sum(l_quantity) AS sum_qty, sum(l_extendedprice) AS sum_base_price, sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price, sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge, avg(l_quantity) AS avg_qty, avg(l_extendedprice) AS avg_price, avg(l_discount) AS avg_disc, count(*) AS count_order FROM lineitem WHERE l_shipdate <= CAST(''1998-09-02'' AS date) GROUP BY l_returnflag, l_linestatus ORDER BY l_returnflag, l_linestatus;', strict = true)
 
-#Q 02 (DELIM_JOIN)
-#statement ok
-#CALL get_substrait('SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment FROM part, supplier, partsupp, nation, region WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND p_size = 15 AND p_type LIKE ''%BRASS'' AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = ''EUROPE'' AND ps_supplycost = ( SELECT min(ps_supplycost) FROM partsupp, supplier, nation, region WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = ''EUROPE'') ORDER BY s_acctbal DESC, n_name, s_name, p_partkey LIMIT 100;', strict = true)
+#Q 02
+statement ok
+CALL get_substrait('SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment FROM part, supplier, partsupp, nation, region WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND p_size = 15 AND p_type LIKE ''%BRASS'' AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = ''EUROPE'' AND ps_supplycost = ( SELECT min(ps_supplycost) FROM partsupp, supplier, nation, region WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = ''EUROPE'') ORDER BY s_acctbal DESC, n_name, s_name, p_partkey LIMIT 100;', strict = true)
 
 #Q 03
 statement ok
 CALL get_substrait('SELECT l_orderkey, sum(l_extendedprice * (1 - l_discount)) AS revenue, o_orderdate, o_shippriority FROM customer, orders, lineitem WHERE c_mktsegment = ''BUILDING'' AND c_custkey = o_custkey AND l_orderkey = o_orderkey AND o_orderdate < CAST(''1995-03-15'' AS date) AND l_shipdate > CAST(''1995-03-15'' AS date) GROUP BY l_orderkey, o_orderdate, o_shippriority ORDER BY revenue DESC, o_orderdate LIMIT 10;', strict = true)
 
-#Q 04  DELIM_JOIN
-#statement ok
-#CALL get_substrait('SELECT o_orderpriority, count(*) AS order_count FROM orders WHERE o_orderdate >= CAST(''1993-07-01'' AS date) AND o_orderdate < CAST(''1993-10-01'' AS date) AND EXISTS ( SELECT * FROM lineitem WHERE l_orderkey = o_orderkey AND l_commitdate < l_receiptdate) GROUP BY o_orderpriority ORDER BY o_orderpriority;', strict = true)
+#Q 04
+statement ok
+CALL get_substrait('SELECT o_orderpriority, count(*) AS order_count FROM orders WHERE o_orderdate >= CAST(''1993-07-01'' AS date) AND o_orderdate < CAST(''1993-10-01'' AS date) AND EXISTS ( SELECT * FROM lineitem WHERE l_orderkey = o_orderkey AND l_commitdate < l_receiptdate) GROUP BY o_orderpriority ORDER BY o_orderpriority;', strict = true)
 
 #Q 05
 statement ok
@@ -78,13 +77,13 @@ CALL get_substrait('SELECT 100.00 * sum( CASE WHEN p_type LIKE ''PROMO%'' THEN l
 statement ok
 CALL get_substrait('WITH revenue AS ( SELECT l_suppkey AS supplier_no, sum(l_extendedprice * (1 - l_discount)) AS total_revenue FROM lineitem WHERE l_shipdate >= CAST(''1996-01-01'' AS date) AND l_shipdate < CAST(''1996-04-01'' AS date) GROUP BY supplier_no) SELECT s_suppkey, s_name, s_address, s_phone, total_revenue FROM supplier, revenue WHERE s_suppkey = supplier_no AND total_revenue = ( SELECT max(total_revenue) FROM revenue) ORDER BY s_suppkey;', strict = true)
 
-#Q 16 (Missing Chunk Get)
-#statement ok
-#CALL get_substrait('SELECT p_brand, p_type, p_size, count(DISTINCT ps_suppkey) AS supplier_cnt FROM partsupp, part WHERE p_partkey = ps_partkey AND p_brand <> ''Brand#45'' AND p_type NOT LIKE ''MEDIUM POLISHED%'' AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9) AND ps_suppkey NOT IN ( SELECT s_suppkey FROM supplier WHERE s_comment LIKE ''%Customer%Complaints%'') GROUP BY p_brand, p_type, p_size ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;', strict = true)
+#Q 16
+statement ok
+CALL get_substrait('SELECT p_brand, p_type, p_size, count(DISTINCT ps_suppkey) AS supplier_cnt FROM partsupp, part WHERE p_partkey = ps_partkey AND p_brand <> ''Brand#45'' AND p_type NOT LIKE ''MEDIUM POLISHED%'' AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9) AND ps_suppkey NOT IN ( SELECT s_suppkey FROM supplier WHERE s_comment LIKE ''%Customer%Complaints%'') GROUP BY p_brand, p_type, p_size ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;', strict = true)
 
-#Q 17 (DELIM_JOIN)
-#statement ok
-#CALL get_substrait('SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, part WHERE p_partkey = l_partkey AND p_brand = ''Brand#23'' AND p_container = ''MED BOX'' AND l_quantity < ( SELECT 0.2 * avg(l_quantity) FROM lineitem WHERE l_partkey = p_partkey);', strict = true)
+#Q 17
+statement ok
+CALL get_substrait('SELECT sum(l_extendedprice) / 7.0 AS avg_yearly FROM lineitem, part WHERE p_partkey = l_partkey AND p_brand = ''Brand#23'' AND p_container = ''MED BOX'' AND l_quantity < ( SELECT 0.2 * avg(l_quantity) FROM lineitem WHERE l_partkey = p_partkey);', strict = true)
 
 #Q 18
 statement ok
@@ -94,17 +93,21 @@ CALL get_substrait('SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalpr
 statement ok
 CALL get_substrait('SELECT sum(l_extendedprice * (1 - l_discount)) AS revenue FROM lineitem, part WHERE (p_partkey = l_partkey AND p_brand = ''Brand#12'' AND p_container IN (''SM CASE'', ''SM BOX'', ''SM PACK'', ''SM PKG'') AND l_quantity >= 1 AND l_quantity <= 1 + 10 AND p_size BETWEEN 1 AND 5 AND l_shipmode IN (''AIR'', ''AIR REG'') AND l_shipinstruct = ''DELIVER IN PERSON'') OR (p_partkey = l_partkey AND p_brand = ''Brand#23'' AND p_container IN (''MED BAG'', ''MED BOX'', ''MED PKG'', ''MED PACK'') AND l_quantity >= 10 AND l_quantity <= 10 + 10 AND p_size BETWEEN 1 AND 10 AND l_shipmode IN (''AIR'', ''AIR REG'') AND l_shipinstruct = ''DELIVER IN PERSON'') OR (p_partkey = l_partkey AND p_brand = ''Brand#34'' AND p_container IN (''LG CASE'', ''LG BOX'', ''LG PACK'', ''LG PKG'') AND l_quantity >= 20 AND l_quantity <= 20 + 10 AND p_size BETWEEN 1 AND 15 AND l_shipmode IN (''AIR'', ''AIR REG'') AND l_shipinstruct = ''DELIVER IN PERSON'');', strict = true)
 
-#Q 20 DELIM_JOIN
-#statement ok
-#CALL get_substrait('SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN ( SELECT ps_suppkey FROM partsupp WHERE ps_partkey IN ( SELECT p_partkey FROM part WHERE p_name LIKE ''forest%'') AND ps_availqty > ( SELECT 0.5 * sum(l_quantity) FROM lineitem WHERE l_partkey = ps_partkey AND l_suppkey = ps_suppkey AND l_shipdate >= CAST(''1994-01-01'' AS date) AND l_shipdate < CAST(''1995-01-01'' AS date))) AND s_nationkey = n_nationkey AND n_name = ''CANADA'' ORDER BY s_name;', strict = true)
+#Q 20
+statement ok
+CALL get_substrait('SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN ( SELECT ps_suppkey FROM partsupp WHERE ps_partkey IN ( SELECT p_partkey FROM part WHERE p_name LIKE ''forest%'') AND ps_availqty > ( SELECT 0.5 * sum(l_quantity) FROM lineitem WHERE l_partkey = ps_partkey AND l_suppkey = ps_suppkey AND l_shipdate >= CAST(''1994-01-01'' AS date) AND l_shipdate < CAST(''1995-01-01'' AS date))) AND s_nationkey = n_nationkey AND n_name = ''CANADA'' ORDER BY s_name;', strict = true)
 
-#Q 21 Delim Join
-#statement ok
-#CALL get_substrait('SELECT s_name, count(*) AS numwait FROM supplier, lineitem l1, orders, nation WHERE s_suppkey = l1.l_suppkey AND o_orderkey = l1.l_orderkey AND o_orderstatus = ''F'' AND l1.l_receiptdate > l1.l_commitdate AND EXISTS ( SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey <> l1.l_suppkey) AND NOT EXISTS ( SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey <> l1.l_suppkey AND l3.l_receiptdate > l3.l_commitdate) AND s_nationkey = n_nationkey AND n_name = ''SAUDI ARABIA'' GROUP BY s_name ORDER BY numwait DESC, s_name LIMIT 100;', strict = true)
+#Q 21 (ANTI)
+statement error
+CALL get_substrait('SELECT s_name, count(*) AS numwait FROM supplier, lineitem l1, orders, nation WHERE s_suppkey = l1.l_suppkey AND o_orderkey = l1.l_orderkey AND o_orderstatus = ''F'' AND l1.l_receiptdate > l1.l_commitdate AND EXISTS ( SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey <> l1.l_suppkey) AND NOT EXISTS ( SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey <> l1.l_suppkey AND l3.l_receiptdate > l3.l_commitdate) AND s_nationkey = n_nationkey AND n_name = ''SAUDI ARABIA'' GROUP BY s_name ORDER BY numwait DESC, s_name LIMIT 100;', strict = true)
+----
+Not implemented Error: Unsupported join type ANTI
 
-#Q 22 Mark Join + Chunk Get
-#statement ok
-#CALL get_substrait('SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctbal FROM ( SELECT substring(c_phone FROM 1 FOR 2) AS cntrycode, c_acctbal FROM customer WHERE substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'') AND c_acctbal > ( SELECT avg(c_acctbal) FROM customer WHERE c_acctbal > 0.00 AND substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'')) AND NOT EXISTS ( SELECT * FROM orders WHERE o_custkey = c_custkey)) AS custsale GROUP BY cntrycode ORDER BY cntrycode;', strict = true)
+#Q 22 (RIGHT_ANTI)
+statement error
+CALL get_substrait('SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctbal FROM ( SELECT substring(c_phone FROM 1 FOR 2) AS cntrycode, c_acctbal FROM customer WHERE substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'') AND c_acctbal > ( SELECT avg(c_acctbal) FROM customer WHERE c_acctbal > 0.00 AND substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'')) AND NOT EXISTS ( SELECT * FROM orders WHERE o_custkey = c_custkey)) AS custsale GROUP BY cntrycode ORDER BY cntrycode;', strict = true)
+----
+Not implemented Error: Unsupported join type RIGHT_ANTI
 
 # Test Get JSON
 statement ok


### PR DESCRIPTION
## Summary

Implements semantically correct conversion of DuckDB's duplicate eliminated joins (`LOGICAL_DELIM_JOIN` / `LOGICAL_DELIM_GET`) to Substrait, spelled out as "duplicate eliminated join" throughout since the `delim` abbreviation reads like *delimiter*.

A duplicate eliminated join is a comparison join that additionally feeds the **distinct values** of some of its data side's columns (the `duplicate_eliminated_columns`) into duplicate eliminated get scans inside its other child. Substrait has no equivalent construct, so:

- The join itself is emitted as a regular `JoinRel` (it *is* a `LogicalComparisonJoin`).
- Each duplicate eliminated get is expanded into an `AggregateRel` (group-by, no measures — i.e. DISTINCT) over a copy of the join's data side, projecting the duplicate eliminated columns. That is exactly the relation the get scans, so the emitted plan is correct for **any** Substrait consumer.
- `delim_flipped` is respected (the data side may be either child), and nested duplicate eliminated joins are handled with a scoped stack so gets always resolve against the correct enclosing join.

### Optimization hints

The data side copy inside each expanded get re-states work the join's own data side already performs. The two are tied together with the `RelCommon.Hint` saved/loaded computation hints: the join's data side carries a `SavedComputation{computation_id}` and each copy carries a `LoadedComputation{computation_id_reference}`. Consumers that ignore hints still get correct results; hint-aware consumers can recognize the copies as reloads and restore delim-join-style execution without recomputing.

### Also fixed

`TransformComparisonJoin` now applies its projection-map-based column-offset correction when the left child is a `LOGICAL_DELIM_JOIN`, not just a `LOGICAL_COMPARISON_JOIN`.

## Test results

Eight TPC-DS queries that previously failed with `Not implemented Error: DELIM_JOIN` now convert **and round-trip with verified matching results** under `PRAGMA enable_verification`: Q1, Q6, Q10, Q32, Q35, Q41, Q81, Q92 — including Q6 (VARCHAR correlation keys) and Q32/Q35. Q16, Q69, and Q94 now surface the unrelated ANTI/RIGHT_ANTI join type gap instead.

A new test file `test_substrait_duplicate_eliminated_join.test` covers integer-key correlation, VARCHAR-key correlation, correlated-EXISTS-with-OR (mark joins), and asserts the saved/loaded computation hints are present. The correlation key values deliberately exceed 1000 so placeholder implementations that only cover small key domains fail. Verified the new tests fail with `Not implemented Error: DELIM_JOIN` when the source changes are reverted.

Full test suite passes (49 test cases, 1277 assertions; httpfs-gated test skipped).

Supersedes the approach in #211.