### PR TITLE
build: update to Substrait v0.91.0

### DIFF
--- a/scripts/generate_custom_functions.py
+++ b/scripts/generate_custom_functions.py
@@ -13,7 +13,7 @@ import regex
 # version, then re-run this script and commit the regenerated
 # src/custom_extensions_generated.cpp.
 SUBSTRAIT_PACKAGING_REPO = "https://github.com/substrait-io/substrait-packaging.git"
-SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.90.0"
+SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.91.0"
 SUBSTRAIT_EXTENSIONS_SUBDIR = os.path.join("cpp", "substrait-extensions", "extensions")
 
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -4,7 +4,7 @@
             "kind": "git",
             "repository": "https://github.com/substrait-io/substrait-packaging",
             "reference": "vcpkg-registry",
-            "baseline": "d71abd164b43306c70dbcee1c33858c74dee9717",
+            "baseline": "a703c3922debb744c53bd8d9cf8a2cb3fc14c7e9",
             "packages": [
                 "substrait-protobuf",
                 "substrait-extensions",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,7 @@
     "overrides": [
         {
             "name": "substrait-protobuf",
-            "version": "0.90.0"
+            "version": "0.91.0"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Updates the Substrait dependencies to [v0.91.0](https://github.com/substrait-io/substrait/releases/tag/v0.91.0).

- **`vcpkg.json`** — `substrait-protobuf` override `0.90.0` → `0.91.0`
- **`vcpkg-configuration.json`** — registry `baseline` bumped to the substrait-packaging `vcpkg-registry` commit that publishes `substrait-protobuf` 0.91.0 and `substrait-extensions` 0.91.0
- **`scripts/generate_custom_functions.py`** — `SUBSTRAIT_EXTENSIONS_TAG` → `cpp/substrait-extensions/v0.91.0`

## Impact of the 0.91.0 changes

- **Breaking change (`subtract:date_iday` return type `date` → `precision_timestamp`)** — no effect here. `SubstraitCustomFunctions::InsertCustomFunction` keys on function name + argument types only, never return types, so regenerating `src/custom_extensions_generated.cpp` produces **no diff**.
- **`residual_expressions` on hash/merge join + `post_join_filter` clarification** — protobuf schema additions, available automatically via the version bump; no code change needed.

## Verification

- `python scripts/generate_custom_functions.py` → regenerated `custom_extensions_generated.cpp` is byte-identical to the committed file.
- `make release` → succeeds; vcpkg resolves and builds `substrait-protobuf@0.91.0` from the new baseline, extension links cleanly.
- `make test_release` → all tests pass (1268 assertions in 48 test cases, 1 skipped).

Closes #216

🤖 Generated with AI