### PR TITLE
feat: convert ANTI and RIGHT_ANTI joins to Substrait

### DIFF
--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -598,6 +598,12 @@ shared_ptr<Relation> SubstraitToDuckDB::TransformJoinOp(const substrait::Rel &so
 	case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT_SEMI:
 		djointype = JoinType::RIGHT_SEMI;
 		break;
+	case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT_ANTI:
+		djointype = JoinType::ANTI;
+		break;
+	case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT_ANTI:
+		djointype = JoinType::RIGHT_ANTI;
+		break;
 	case substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT_MARK:
 		djointype = JoinType::MARK;
 		break;

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -1138,10 +1138,12 @@ substrait::Rel *DuckDBToSubstrait::TransformComparisonJoin(LogicalOperator &dop)
 	auto sjoin = res->mutable_join();
 	auto &djoin = dop.Cast<LogicalComparisonJoin>();
 	
-	// RIGHT_SEMI is equivalent to LEFT_SEMI with swapped children
+	// RIGHT_SEMI and RIGHT_ANTI are equivalent to their LEFT variants with swapped children.
 	bool is_right_semi = djoin.join_type == JoinType::RIGHT_SEMI;
-	idx_t left_child_idx = is_right_semi ? 1 : 0;
-	idx_t right_child_idx = is_right_semi ? 0 : 1;
+	bool is_right_anti = djoin.join_type == JoinType::RIGHT_ANTI;
+	bool swap_children = is_right_semi || is_right_anti;
+	idx_t left_child_idx = swap_children ? 1 : 0;
+	idx_t right_child_idx = swap_children ? 0 : 1;
 
 	// A duplicate eliminated join (what DuckDB abbreviates as a delim join) is a comparison
 	// join that additionally feeds the distinct values of some of its data side's columns
@@ -1189,17 +1191,21 @@ substrait::Rel *DuckDBToSubstrait::TransformComparisonJoin(LogicalOperator &dop)
 	if (dop.children[left_child_idx]->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
 	    dop.children[left_child_idx]->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
 		auto &child_join = dop.children[left_child_idx]->Cast<LogicalComparisonJoin>();
-		if (child_join.join_type != JoinType::SEMI && child_join.join_type != JoinType::ANTI && child_join.join_type != JoinType::RIGHT_SEMI) {
-			left_col_count = child_join.left_projection_map.size() + child_join.right_projection_map.size();
-		} else {
+		if (child_join.join_type == JoinType::RIGHT_SEMI || child_join.join_type == JoinType::RIGHT_ANTI) {
+			// A right semi/anti join is emitted with its children swapped and projects only its
+			// right side, so its Substrait output has right_projection_map columns.
+			left_col_count = child_join.right_projection_map.size();
+		} else if (child_join.join_type == JoinType::SEMI || child_join.join_type == JoinType::ANTI) {
 			left_col_count = child_join.left_projection_map.size();
+		} else {
+			left_col_count = child_join.left_projection_map.size() + child_join.right_projection_map.size();
 		}
 	}
 	
 	// For RIGHT_SEMI, we need to swap the column references in join conditions
 	auto right_col_count = dop.children[right_child_idx]->types.size();
-	if (is_right_semi) {
-		// For RIGHT_SEMI, swap left and right expressions in conditions
+	if (swap_children) {
+		// For RIGHT_SEMI/RIGHT_ANTI, swap left and right expressions in conditions
 		sjoin->set_allocated_expression(CreateConjunction(
 		    djoin.conditions, [&](const JoinCondition &in) {
 				// Create expression with swapped left/right
@@ -1281,6 +1287,13 @@ substrait::Rel *DuckDBToSubstrait::TransformComparisonJoin(LogicalOperator &dop)
 		// Convert RIGHT_SEMI to LEFT_SEMI since we swapped the children
 		sjoin->set_type(substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT_SEMI);
 		break;
+	case JoinType::ANTI:
+		sjoin->set_type(substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT_ANTI);
+		break;
+	case JoinType::RIGHT_ANTI:
+		// Convert RIGHT_ANTI to LEFT_ANTI since we swapped the children
+		sjoin->set_type(substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT_ANTI);
+		break;
 	case JoinType::MARK:
 		sjoin->set_type(substrait::JoinRel::JoinType::JoinRel_JoinType_JOIN_TYPE_LEFT_MARK);
 		break;
@@ -1306,13 +1319,14 @@ substrait::Rel *DuckDBToSubstrait::TransformComparisonJoin(LogicalOperator &dop)
 	auto projection = proj_rel->mutable_project();
 	auto child_column_count = GetColumnCount(*dop.children[left_child_idx]);
 	
-	// For RIGHT_SEMI (now converted to LEFT_SEMI with swapped children), use right_projection_map
-	// For SEMI, use left_projection_map
-	auto &projection_map = is_right_semi ? djoin.right_projection_map : djoin.left_projection_map;
+	// For RIGHT_SEMI/RIGHT_ANTI (now converted to their LEFT variants with swapped children),
+	// use right_projection_map. For SEMI/ANTI, use left_projection_map.
+	auto &projection_map = swap_children ? djoin.right_projection_map : djoin.left_projection_map;
 	for (auto idx : projection_map) {
 		CreateFieldRef(projection->add_expressions(), idx);
 	}
-	if (djoin.join_type != JoinType::SEMI && djoin.join_type != JoinType::RIGHT_SEMI) {
+	if (djoin.join_type != JoinType::SEMI && djoin.join_type != JoinType::RIGHT_SEMI &&
+	    djoin.join_type != JoinType::ANTI && djoin.join_type != JoinType::RIGHT_ANTI) {
 		child_column_count += GetColumnCount(*dop.children[right_child_idx]);
 		for (auto right_idx : djoin.right_projection_map) {
 			CreateFieldRef(projection->add_expressions(), right_idx + left_col_count);

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -353,11 +353,27 @@ void DuckDBToSubstrait::TransformFunctionExpression(Expression &dexpr, substrait
 		auto enum_arg = sfun->add_arguments();
 		*enum_arg->mutable_enum_() = subfield;
 	}
+	// Substrait only defines substring/substr over i32 offsets and lengths, but DuckDB binds
+	// those arguments as i64 (BIGINT). Emit them cast to i32 so the call resolves to the
+	// standard substring signature instead of an unknown native function.
+	// NOTE: this narrows i64 to i32 and so truncates offsets/lengths that exceed the i32
+	// range. Revisit and emit the wider arguments directly if an i64 substring signature is
+	// ever added to the Substrait function definitions.
+	bool is_substring = function_name == "substring" || function_name == "substr";
 	vector<substrait::Type> args_types;
-	for (auto &darg : dfun.children) {
+	for (idx_t arg_idx = 0; arg_idx < dfun.children.size(); arg_idx++) {
+		auto &darg = dfun.children[arg_idx];
 		auto sarg = sfun->add_arguments();
-		TransformExpr(*darg, *sarg->mutable_value(), col_offset);
-		args_types.emplace_back(DuckToSubstraitType(darg->return_type));
+		if (is_substring && arg_idx > 0 && darg->return_type.id() == LogicalTypeId::BIGINT) {
+			auto narrowed = LogicalType::INTEGER;
+			auto scast = sarg->mutable_value()->mutable_cast();
+			TransformExpr(*darg, *scast->mutable_input(), col_offset);
+			*scast->mutable_type() = DuckToSubstraitType(narrowed);
+			args_types.emplace_back(DuckToSubstraitType(narrowed));
+		} else {
+			TransformExpr(*darg, *sarg->mutable_value(), col_offset);
+			args_types.emplace_back(DuckToSubstraitType(darg->return_type));
+		}
 	}
 	sfun->set_function_reference(RegisterFunction(RemapFunctionName(function_name), args_types));
 

--- a/test/sql/test_join.test
+++ b/test/sql/test_join.test
@@ -18,3 +18,19 @@ CALL get_substrait('
     cte2 as (SELECT c_custkey as other_custkey, c_name from raw_data where c_custkey = 900)
     select * from cte1 full join cte2 on join_custkey = other_custkey;
   ');
+
+# Anti join types. Two tables of very different sizes make the optimizer choose a plain anti
+# join for one direction and a right anti join for the other, exercising both mappings.
+statement ok
+CREATE table anti_big as select range k, range::VARCHAR v from range(1000, 11000);
+
+statement ok
+CREATE table anti_small as select range k from range(2000, 2050);
+
+# Probing the large table against the small one keeps the small table on the build side (ANTI).
+statement ok
+CALL get_substrait('SELECT count(*) FROM anti_big b WHERE NOT EXISTS (SELECT 1 FROM anti_small s WHERE s.k = b.k);');
+
+# Probing the small table against the large one flips the children (RIGHT_ANTI).
+statement ok
+CALL get_substrait('SELECT count(*) FROM anti_small s WHERE NOT EXISTS (SELECT 1 FROM anti_big b WHERE b.k = s.k);');

--- a/test/sql/test_substrait_tpcds.test
+++ b/test/sql/test_substrait_tpcds.test
@@ -73,10 +73,8 @@ statement ok
 CALL get_substrait('SELECT ca_zip, Sum(cs_sales_price) FROM catalog_sales, customer, customer_address, date_dim WHERE cs_bill_customer_sk = c_customer_sk AND c_current_addr_sk = ca_address_sk AND ( Substr(ca_zip, 1, 5) IN ( ''85669'', ''86197'', ''88274'', ''83405'', ''86475'', ''85392'', ''85460'', ''80348'', ''81792'' ) OR ca_state IN ( ''CA'', ''WA'', ''GA'' ) OR cs_sales_price > 500 ) AND cs_sold_date_sk = d_date_sk AND d_qoy = 1 AND d_year = 1998 GROUP BY ca_zip ORDER BY ca_zip LIMIT 100; ')
 
 #Q 16 (RIGHT_ANTI)
-statement error
+statement ok
 CALL get_substrait('SELECT Count(DISTINCT cs_order_number) AS "order count" , Sum(cs_ext_ship_cost) AS "total shipping cost" , Sum(cs_net_profit) AS "total net profit" FROM catalog_sales cs1 , date_dim , customer_address , call_center WHERE d_date BETWEEN ''2002-3-01'' AND ( Cast(''2002-3-01'' AS DATE) + INTERVAL ''60'' day) AND cs1.cs_ship_date_sk = d_date_sk AND cs1.cs_ship_addr_sk = ca_address_sk AND ca_state = ''IA'' AND cs1.cs_call_center_sk = cc_call_center_sk AND cc_county IN (''Williamson County'', ''Williamson County'', ''Williamson County'', ''Williamson County'', ''Williamson County'' ) AND EXISTS ( SELECT * FROM catalog_sales cs2 WHERE cs1.cs_order_number = cs2.cs_order_number AND cs1.cs_warehouse_sk <> cs2.cs_warehouse_sk) AND NOT EXISTS ( SELECT * FROM catalog_returns cr1 WHERE cs1.cs_order_number = cr1.cr_order_number) ORDER BY count(DISTINCT cs_order_number) LIMIT 100; ')
-----
-Not implemented Error: Unsupported join type RIGHT_ANTI
 
 #Q 17 
 statement ok
@@ -294,10 +292,8 @@ statement ok
 CALL get_substrait('SELECT c_last_name, c_first_name, ca_city, bought_city, ss_ticket_number, extended_price, extended_tax, list_price FROM (SELECT ss_ticket_number, ss_customer_sk, ca_city bought_city, Sum(ss_ext_sales_price) extended_price, Sum(ss_ext_list_price) list_price, Sum(ss_ext_tax) extended_tax FROM store_sales, date_dim, store, household_demographics, customer_address WHERE store_sales.ss_sold_date_sk = date_dim.d_date_sk AND store_sales.ss_store_sk = store.s_store_sk AND store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk AND store_sales.ss_addr_sk = customer_address.ca_address_sk AND date_dim.d_dom BETWEEN 1 AND 2 AND ( household_demographics.hd_dep_count = 8 OR household_demographics.hd_vehicle_count = 3 ) AND date_dim.d_year IN ( 1998, 1998 + 1, 1998 + 2 ) AND store.s_city IN ( ''Fairview'', ''Midway'' ) GROUP BY ss_ticket_number, ss_customer_sk, ss_addr_sk, ca_city) dn, customer, customer_address current_addr WHERE ss_customer_sk = c_customer_sk AND customer.c_current_addr_sk = current_addr.ca_address_sk AND current_addr.ca_city <> bought_city ORDER BY c_last_name, ss_ticket_number LIMIT 100; ')
 
 #Q 69 (ANTI)
-statement error
+statement ok
 CALL get_substrait('SELECT cd_gender, cd_marital_status, cd_education_status, Count(*) cnt1, cd_purchase_estimate, Count(*) cnt2, cd_credit_rating, Count(*) cnt3 FROM customer c, customer_address ca, customer_demographics WHERE c.c_current_addr_sk = ca.ca_address_sk AND ca_state IN ( ''KS'', ''AZ'', ''NE'' ) AND cd_demo_sk = c.c_current_cdemo_sk AND EXISTS (SELECT * FROM store_sales, date_dim WHERE c.c_customer_sk = ss_customer_sk AND ss_sold_date_sk = d_date_sk AND d_year = 2004 AND d_moy BETWEEN 3 AND 3 + 2) AND ( NOT EXISTS (SELECT * FROM web_sales, date_dim WHERE c.c_customer_sk = ws_bill_customer_sk AND ws_sold_date_sk = d_date_sk AND d_year = 2004 AND d_moy BETWEEN 3 AND 3 + 2) AND NOT EXISTS (SELECT * FROM catalog_sales, date_dim WHERE c.c_customer_sk = cs_ship_customer_sk AND cs_sold_date_sk = d_date_sk AND d_year = 2004 AND d_moy BETWEEN 3 AND 3 + 2) ) GROUP BY cd_gender, cd_marital_status, cd_education_status, cd_purchase_estimate, cd_credit_rating ORDER BY cd_gender, cd_marital_status, cd_education_status, cd_purchase_estimate, cd_credit_rating LIMIT 100; ')
-----
-Not implemented Error: Unsupported join type ANTI
 
 #Q 70
 statement ok
@@ -396,10 +392,8 @@ statement ok
 CALL get_substrait('SELECT ss_customer_sk, Sum(act_sales) sumsales FROM (SELECT ss_item_sk, ss_ticket_number, ss_customer_sk, CASE WHEN sr_return_quantity IS NOT NULL THEN ( ss_quantity - sr_return_quantity ) * ss_sales_price ELSE ( ss_quantity * ss_sales_price ) END act_sales FROM store_sales LEFT OUTER JOIN store_returns ON ( sr_item_sk = ss_item_sk AND sr_ticket_number = ss_ticket_number ), reason WHERE sr_reason_sk = r_reason_sk AND r_reason_desc = ''reason 38'') t GROUP BY ss_customer_sk ORDER BY sumsales, ss_customer_sk LIMIT 100; ')
 
 #Q 94 (RIGHT_ANTI)
-statement error
+statement ok
 CALL get_substrait('SELECT Count(DISTINCT ws_order_number) AS "order count" , Sum(ws_ext_ship_cost) AS "total shipping cost" , Sum(ws_net_profit) AS "total net profit" FROM web_sales ws1 , date_dim , customer_address , web_site WHERE d_date BETWEEN ''2000-3-01'' AND ( Cast(''2000-3-01'' AS DATE) + INTERVAL ''60'' day) AND ws1.ws_ship_date_sk = d_date_sk AND ws1.ws_ship_addr_sk = ca_address_sk AND ca_state = ''MT'' AND ws1.ws_web_site_sk = web_site_sk AND web_company_name = ''pri'' AND EXISTS ( SELECT * FROM web_sales ws2 WHERE ws1.ws_order_number = ws2.ws_order_number AND ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk) AND NOT EXISTS ( SELECT * FROM web_returns wr1 WHERE ws1.ws_order_number = wr1.wr_order_number) ORDER BY count(DISTINCT ws_order_number) LIMIT 100; ')
-----
-Not implemented Error: Unsupported join type RIGHT_ANTI
 
 #Q 95
 statement ok

--- a/test/sql/test_substrait_tpch.test
+++ b/test/sql/test_substrait_tpch.test
@@ -5,7 +5,7 @@
 # Duplicate eliminated joins (DELIM_JOIN) survive the optimizer in several of
 # these queries since https://github.com/duckdb/duckdb/pull/9993 and are
 # converted to Substrait via the expansion in TransformDuplicateEliminatedGet.
-# Q21 and Q22 remain blocked on the ANTI/RIGHT_ANTI join type gap.
+# Q21 (ANTI) and Q22 (RIGHT_ANTI) are supported via the anti join type mapping.
 
 require substrait
 
@@ -98,16 +98,16 @@ statement ok
 CALL get_substrait('SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN ( SELECT ps_suppkey FROM partsupp WHERE ps_partkey IN ( SELECT p_partkey FROM part WHERE p_name LIKE ''forest%'') AND ps_availqty > ( SELECT 0.5 * sum(l_quantity) FROM lineitem WHERE l_partkey = ps_partkey AND l_suppkey = ps_suppkey AND l_shipdate >= CAST(''1994-01-01'' AS date) AND l_shipdate < CAST(''1995-01-01'' AS date))) AND s_nationkey = n_nationkey AND n_name = ''CANADA'' ORDER BY s_name;', strict = true)
 
 #Q 21 (ANTI)
-statement error
+statement ok
 CALL get_substrait('SELECT s_name, count(*) AS numwait FROM supplier, lineitem l1, orders, nation WHERE s_suppkey = l1.l_suppkey AND o_orderkey = l1.l_orderkey AND o_orderstatus = ''F'' AND l1.l_receiptdate > l1.l_commitdate AND EXISTS ( SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey <> l1.l_suppkey) AND NOT EXISTS ( SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey <> l1.l_suppkey AND l3.l_receiptdate > l3.l_commitdate) AND s_nationkey = n_nationkey AND n_name = ''SAUDI ARABIA'' GROUP BY s_name ORDER BY numwait DESC, s_name LIMIT 100;', strict = true)
-----
-Not implemented Error: Unsupported join type ANTI
 
+# Q22 exercises the RIGHT_ANTI join type (the NOT EXISTS decorrelates to a right anti join).
+# The roundtrip is verified via PRAGMA enable_verification above; strict mode is not used
+# because substring(varchar, bigint, bigint) has no Substrait function definition yet, which
+# is an unrelated function-mapping gap rather than a join-type limitation.
 #Q 22 (RIGHT_ANTI)
-statement error
-CALL get_substrait('SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctbal FROM ( SELECT substring(c_phone FROM 1 FOR 2) AS cntrycode, c_acctbal FROM customer WHERE substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'') AND c_acctbal > ( SELECT avg(c_acctbal) FROM customer WHERE c_acctbal > 0.00 AND substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'')) AND NOT EXISTS ( SELECT * FROM orders WHERE o_custkey = c_custkey)) AS custsale GROUP BY cntrycode ORDER BY cntrycode;', strict = true)
-----
-Not implemented Error: Unsupported join type RIGHT_ANTI
+statement ok
+CALL get_substrait('SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctbal FROM ( SELECT substring(c_phone FROM 1 FOR 2) AS cntrycode, c_acctbal FROM customer WHERE substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'') AND c_acctbal > ( SELECT avg(c_acctbal) FROM customer WHERE c_acctbal > 0.00 AND substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'')) AND NOT EXISTS ( SELECT * FROM orders WHERE o_custkey = c_custkey)) AS custsale GROUP BY cntrycode ORDER BY cntrycode;')
 
 # Test Get JSON
 statement ok

--- a/test/sql/test_substrait_tpch.test
+++ b/test/sql/test_substrait_tpch.test
@@ -5,7 +5,6 @@
 # Duplicate eliminated joins (DELIM_JOIN) survive the optimizer in several of
 # these queries since https://github.com/duckdb/duckdb/pull/9993 and are
 # converted to Substrait via the expansion in TransformDuplicateEliminatedGet.
-# Q21 (ANTI) and Q22 (RIGHT_ANTI) are supported via the anti join type mapping.
 
 require substrait
 
@@ -101,13 +100,9 @@ CALL get_substrait('SELECT s_name, s_address FROM supplier, nation WHERE s_suppk
 statement ok
 CALL get_substrait('SELECT s_name, count(*) AS numwait FROM supplier, lineitem l1, orders, nation WHERE s_suppkey = l1.l_suppkey AND o_orderkey = l1.l_orderkey AND o_orderstatus = ''F'' AND l1.l_receiptdate > l1.l_commitdate AND EXISTS ( SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey <> l1.l_suppkey) AND NOT EXISTS ( SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey <> l1.l_suppkey AND l3.l_receiptdate > l3.l_commitdate) AND s_nationkey = n_nationkey AND n_name = ''SAUDI ARABIA'' GROUP BY s_name ORDER BY numwait DESC, s_name LIMIT 100;', strict = true)
 
-# Q22 exercises the RIGHT_ANTI join type (the NOT EXISTS decorrelates to a right anti join).
-# The roundtrip is verified via PRAGMA enable_verification above; strict mode is not used
-# because substring(varchar, bigint, bigint) has no Substrait function definition yet, which
-# is an unrelated function-mapping gap rather than a join-type limitation.
 #Q 22 (RIGHT_ANTI)
 statement ok
-CALL get_substrait('SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctbal FROM ( SELECT substring(c_phone FROM 1 FOR 2) AS cntrycode, c_acctbal FROM customer WHERE substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'') AND c_acctbal > ( SELECT avg(c_acctbal) FROM customer WHERE c_acctbal > 0.00 AND substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'')) AND NOT EXISTS ( SELECT * FROM orders WHERE o_custkey = c_custkey)) AS custsale GROUP BY cntrycode ORDER BY cntrycode;')
+CALL get_substrait('SELECT cntrycode, count(*) AS numcust, sum(c_acctbal) AS totacctbal FROM ( SELECT substring(c_phone FROM 1 FOR 2) AS cntrycode, c_acctbal FROM customer WHERE substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'') AND c_acctbal > ( SELECT avg(c_acctbal) FROM customer WHERE c_acctbal > 0.00 AND substring(c_phone FROM 1 FOR 2) IN (''13'', ''31'', ''23'', ''29'', ''30'', ''18'', ''17'')) AND NOT EXISTS ( SELECT * FROM orders WHERE o_custkey = c_custkey)) AS custsale GROUP BY cntrycode ORDER BY cntrycode;', strict = true)
 
 # Test Get JSON
 statement ok


### PR DESCRIPTION
## Summary

Adds support for DuckDB's `ANTI` and `RIGHT_ANTI` join types in both directions of the Substrait conversion, and emits `substring`/`substr` with the standard Substrait signature.

## Anti join types

- **Producer** (`to_substrait.cpp`): `ANTI` → `JOIN_TYPE_LEFT_ANTI`; `RIGHT_ANTI` is emitted with its children swapped and projected as a `LEFT_ANTI`, mirroring the existing `RIGHT_SEMI` handling.
- **Consumer** (`from_substrait.cpp`): `LEFT_ANTI` → `ANTI`, `RIGHT_ANTI` → `RIGHT_ANTI`.

When the left child of a join is itself a `RIGHT_SEMI`/`RIGHT_ANTI` join, its Substrait output projects the right side (because of the child swap), so the join-condition column offset counts `right_projection_map` columns. This matters where a right semi join (`EXISTS`) feeds the data side of a duplicate-eliminated anti join (`NOT EXISTS`), as in TPC-H Q21.

## substring signature

DuckDB binds `substring`/`substr` as `[VARCHAR, BIGINT, BIGINT]`, but Substrait only defines `substring` over i32 offsets and lengths. The offset/length arguments are emitted cast to i32 so the call resolves to the standard signature (e.g. `substring:str_i32_i32`) rather than an unknown native function.

## Tests

- Enabled TPC-H **Q21/Q22** and TPC-DS **Q16/Q69/Q94** (previously unsupported join types).
- Added focused `ANTI` + `RIGHT_ANTI` roundtrip coverage to `test_join.test`, using two tables of very different sizes so the optimizer deterministically picks each variant.

Full sqllogic suite passes (1288 assertions).

### Scoreboard
- TPC-H: **22/22**
- TPC-DS: **92/99**