### PR TITLE
build: update to Substrait v0.92.0

### DIFF
--- a/scripts/generate_custom_functions.py
+++ b/scripts/generate_custom_functions.py
@@ -13,7 +13,7 @@ import regex
 # version, then re-run this script and commit the regenerated
 # src/custom_extensions_generated.cpp.
 SUBSTRAIT_PACKAGING_REPO = "https://github.com/substrait-io/substrait-packaging.git"
-SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.91.0"
+SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.92.0"
 SUBSTRAIT_EXTENSIONS_SUBDIR = os.path.join("cpp", "substrait-extensions", "extensions")
 
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -4,7 +4,7 @@
             "kind": "git",
             "repository": "https://github.com/substrait-io/substrait-packaging",
             "reference": "vcpkg-registry",
-            "baseline": "a703c3922debb744c53bd8d9cf8a2cb3fc14c7e9",
+            "baseline": "f15ab969466afd667afd985f98a521df77ede143",
             "packages": [
                 "substrait-protobuf",
                 "substrait-extensions",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,7 @@
     "overrides": [
         {
             "name": "substrait-protobuf",
-            "version": "0.91.0"
+            "version": "0.92.0"
         }
     ]
 }


### PR DESCRIPTION
Upgrade the Substrait protobuf dependency from v0.91.0 to v0.92.0. This includes updating the substrait-packaging vcpkg registry baseline and regenerating custom function definitions.

Resolves #217 