### PR TITLE
build: update to Substrait v0.92.1

### DIFF
--- a/scripts/generate_custom_functions.py
+++ b/scripts/generate_custom_functions.py
@@ -13,7 +13,7 @@ import regex
 # version, then re-run this script and commit the regenerated
 # src/custom_extensions_generated.cpp.
 SUBSTRAIT_PACKAGING_REPO = "https://github.com/substrait-io/substrait-packaging.git"
-SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.92.0"
+SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.92.1"
 SUBSTRAIT_EXTENSIONS_SUBDIR = os.path.join("cpp", "substrait-extensions", "extensions")
 
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -4,7 +4,7 @@
             "kind": "git",
             "repository": "https://github.com/substrait-io/substrait-packaging",
             "reference": "vcpkg-registry",
-            "baseline": "f15ab969466afd667afd985f98a521df77ede143",
+            "baseline": "b3d1ef8553a0998d0a7c19f84575203070d668ff",
             "packages": [
                 "substrait-protobuf",
                 "substrait-extensions",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,7 @@
     "overrides": [
         {
             "name": "substrait-protobuf",
-            "version": "0.92.0"
+            "version": "0.92.1"
         }
     ]
 }


### PR DESCRIPTION
Upgrade the Substrait protobuf dependency from v0.92.0 to v0.92.1. This is a patch release that includes a bug fix for aligning type expressions with extension YAML configurations.

Resolves https://github.com/substrait-io/duckdb-substrait-extension/issues/218