### PR TITLE
fix: only ingest functions_*.yaml extension definitions (#214)

### DIFF
--- a/scripts/generate_custom_functions.py
+++ b/scripts/generate_custom_functions.py
@@ -16,6 +16,26 @@ SUBSTRAIT_PACKAGING_REPO = "https://github.com/substrait-io/substrait-packaging.
 SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.94.0"
 SUBSTRAIT_EXTENSIONS_SUBDIR = os.path.join("cpp", "substrait-extensions", "extensions")
 
+# Only ingest extension YAMLs that declare real Substrait functions. Every
+# legitimate function extension follows the `functions_*.yaml` naming
+# convention, so we allowlist by that prefix rather than walking every YAML in
+# the directory. This deliberately skips:
+#   * example/placeholder extensions -- notably `unknown.yaml`, which declares a
+#     custom `unknown` type and defines add/subtract/.../count over it under the
+#     placeholder URN `extension:io.substrait:unknown`. Ingesting it produced
+#     fabricated signatures and a bogus URN that could clobber real
+#     registrations (see issue #214).
+#   * type-only definitions (`extension_types.yaml`, `type_variations.yaml`),
+#     which declare no functions.
+# This mirrors substrait-java, which loads an explicit `functions_*.yaml`
+# allowlist. Type combinations not covered by a real extension then correctly
+# fall back to `native` instead of referencing a fake URN.
+FUNCTION_EXTENSION_PREFIX = "functions_"
+
+
+def is_function_extension(file_name):
+	return file_name.startswith(FUNCTION_EXTENSION_PREFIX) and file_name.endswith(".yaml")
+
 
 def parse_function_data(functions,yaml_data,function_type):
 	for function_data in yaml_data.get(function_type, []):
@@ -51,6 +71,9 @@ def get_custom_functions(custom_extension_folder):
 	type_set = set()
 	custom_function_paths = next(walk(custom_extension_folder), (None, None, []))[2]
 	for custom_function_path in custom_function_paths:
+		if not is_function_extension(custom_function_path):
+			print(f"Skipping non-function extension YAML: {custom_function_path}")
+			continue
 		# Each extension YAML declares its own Substrait URN
 		# (extension:<owner>:<id>); use it directly rather than reconstructing it
 		# from the file name.

--- a/src/custom_extensions.cpp
+++ b/src/custom_extensions.cpp
@@ -21,7 +21,7 @@ string TransformTypes(const substrait::Type &type) {
 	return string(field->name());
 }
 
-// Concrete types over which an `any`/`any1`/`unknown` argument is expanded when
+// Concrete types over which an `any`/`any1` argument is expanded when
 // pre-building the overload maps. Each token is a protobuf Type.kind field name
 // (what TransformTypes() derives from a concrete argument), so the expanded
 // overloads match at lookup -- these are proto kind names, not the abbreviated
@@ -61,6 +61,12 @@ void SubstraitCustomFunctions::InsertAllFunctions(const vector<vector<string>> &
 			type = StringUtil::Replace(type, "boolean", "bool");
 			type = StringUtil::Replace(type, "fixedchar", "fixed_char");
 			type = StringUtil::Replace(type, "fixedbinary", "fixed_binary");
+			// functions_arithmetic_decimal spells the aggregate sum/avg argument
+			// `DECIMAL` (uppercase) while its scalar functions and every other
+			// extension use lowercase `decimal`; TransformTypes() only ever yields
+			// the lowercase proto kind name, so canonicalize the case here or the
+			// decimal sum/avg overloads never resolve.
+			type = StringUtil::Replace(type, "DECIMAL", "decimal");
 			types.push_back(type);
 		}
 		if (types.empty()) {
@@ -93,7 +99,7 @@ void SubstraitCustomFunctions::InsertCustomFunction(string name_p, vector<string
 	auto types = std::move(types_p);
 	vector<vector<string>> all_types;
 	for (auto &t : types) {
-		if (t == "any1" || t == "unknown" || t == "any") {
+		if (t == "any1" || t == "any") {
 			all_types.emplace_back(GetAllTypes());
 		} else {
 			all_types.push_back({t});

--- a/src/custom_extensions_generated.cpp
+++ b/src/custom_extensions_generated.cpp
@@ -169,16 +169,6 @@ void SubstraitCustomFunctions::Initialize() {
 	InsertCustomFunction("log1p", {"fp32"}, "extension:io.substrait:functions_logarithmic");
 	InsertCustomFunction("log1p", {"fp64"}, "extension:io.substrait:functions_logarithmic");
 	InsertCustomFunction("log1p", {"decimal"}, "extension:io.substrait:functions_logarithmic");
-	InsertCustomFunction("add", {"unknown", "unknown"}, "extension:io.substrait:unknown");
-	InsertCustomFunction("subtract", {"unknown", "unknown"}, "extension:io.substrait:unknown");
-	InsertCustomFunction("multiply", {"unknown", "unknown"}, "extension:io.substrait:unknown");
-	InsertCustomFunction("divide", {"unknown", "unknown"}, "extension:io.substrait:unknown");
-	InsertCustomFunction("modulus", {"unknown", "unknown"}, "extension:io.substrait:unknown");
-	InsertCustomFunction("sum", {"unknown"}, "extension:io.substrait:unknown");
-	InsertCustomFunction("avg", {"unknown"}, "extension:io.substrait:unknown");
-	InsertCustomFunction("min", {"unknown"}, "extension:io.substrait:unknown");
-	InsertCustomFunction("max", {"unknown"}, "extension:io.substrait:unknown");
-	InsertCustomFunction("count", {"unknown"}, "extension:io.substrait:unknown");
 	InsertCustomFunction("concat", {"varchar"}, "extension:io.substrait:functions_string");
 	InsertCustomFunction("concat", {"string"}, "extension:io.substrait:functions_string");
 	InsertCustomFunction("like", {"varchar", "varchar"}, "extension:io.substrait:functions_string");

--- a/test/c/test_projection.cpp
+++ b/test/c/test_projection.cpp
@@ -85,12 +85,12 @@ TEST_CASE("Test C ReadRel projection clause with two passthrough columns with Su
 	REQUIRE(CHECK_COLUMN(result, 1, {120000, 80000, 50000, 95000, 60000}));
 }
 
-// NOTE: in some cases below (equal:i32_i32, avg:dec) a Substrait function
-// currently resolves without a valid extension URN, so its extensionUrns entry
-// carries only the anchor and no "urn". That is a pre-existing resolution gap
-// (e.g. the functions_arithmetic_decimal YAML declares the arg type as
-// "DECIMAL" while plans emit "decimal", so the lookup misses), tracked as a
-// follow-up -- the absent urn is not correct-by-design.
+// NOTE: equal:i32_i32 below still resolves without a valid extension URN, so
+// its extensionUrns entry carries only the anchor and no "urn". That is a
+// pre-existing resolution gap: the any1/any1 overload is expanded over the
+// concrete-type cross-product, and only the first expanded entry keeps the
+// URN, leaving the rest (e.g. i32/i32) empty. Tracked as a follow-up -- the
+// absent urn is not correct-by-design.
 TEST_CASE("Test C ReadRel projection clause with two passthrough columns and filter", "[substrait-api]") {
 	DuckDB db(nullptr);
 	Connection con(db);
@@ -142,7 +142,7 @@ TEST_CASE("Test C ReadRel projection clause 1 passthrough column and 1 aggregate
 	CreateEmployeeTable(con);
 
 	auto json_str = GetSubstraitJSON(con, "SELECT department_id, AVG(salary) AS avg_salary FROM employees GROUP BY department_id");
-	auto expected_json_str = R"({"extensions":[{"extensionFunction":{"functionAnchor":1,"name":"avg:dec","extensionUrnReference":1}}],"relations":[{"root":{"input":{"aggregate":{"input":{"read":{"baseSchema":{"names":["employee_id","name","department_id","salary"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_REQUIRED"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}},{"i32":{"nullability":"NULLABILITY_NULLABLE"}},{"decimal":{"scale":2,"precision":10,"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"projection":{"select":{"structItems":[{"field":2},{"field":3}]},"maintainSingularStruct":true},"namedTable":{"names":["employees"]}}},"groupings":[{"expressionReferences":[0]}],"measures":[{"measure":{"functionReference":1,"outputType":{"fp64":{"nullability":"NULLABILITY_NULLABLE"}},"arguments":[{"value":{"selection":{"directReference":{"structField":{"field":1}},"rootReference":{}}}}]}}],"groupingExpressions":[{"selection":{"directReference":{"structField":{}},"rootReference":{}}}]}},"names":["department_id","avg_salary"]}}],"version":{"minorNumber":78,"producer":"DuckDB"},"extensionUrns":[{"extensionUrnAnchor":1}]})";
+	auto expected_json_str = R"({"extensions":[{"extensionFunction":{"functionAnchor":1,"name":"avg:dec","extensionUrnReference":1}}],"relations":[{"root":{"input":{"aggregate":{"input":{"read":{"baseSchema":{"names":["employee_id","name","department_id","salary"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_REQUIRED"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}},{"i32":{"nullability":"NULLABILITY_NULLABLE"}},{"decimal":{"scale":2,"precision":10,"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"projection":{"select":{"structItems":[{"field":2},{"field":3}]},"maintainSingularStruct":true},"namedTable":{"names":["employees"]}}},"groupings":[{"expressionReferences":[0]}],"measures":[{"measure":{"functionReference":1,"outputType":{"fp64":{"nullability":"NULLABILITY_NULLABLE"}},"arguments":[{"value":{"selection":{"directReference":{"structField":{"field":1}},"rootReference":{}}}}]}}],"groupingExpressions":[{"selection":{"directReference":{"structField":{}},"rootReference":{}}}]}},"names":["department_id","avg_salary"]}}],"version":{"minorNumber":78,"producer":"DuckDB"},"extensionUrns":[{"extensionUrnAnchor":1,"urn":"extension:io.substrait:functions_arithmetic_decimal"}]})";
 	REQUIRE(json_str == expected_json_str);
 	auto result = FromSubstraitJSON(con, json_str);
 	REQUIRE(CHECK_COLUMN(result, 0, {1, 2, 3}));


### PR DESCRIPTION
Fixes #214.

## Problem

`scripts/generate_custom_functions.py` walked the entire Substrait extensions directory and ingested **every** YAML it found — including [`extensions/unknown.yaml`](https://github.com/substrait-io/substrait/blob/main/extensions/unknown.yaml), an example/placeholder extension (`urn: extension:io.substrait:unknown`) that declares a custom type literally named `unknown` and defines `add`/`subtract`/`multiply`/`divide`/`modulus`/`sum`/`avg`/`min`/`max`/`count` over it.

Consequences:

1. **Clobbering:** `InsertCustomFunction` treats the custom `unknown` type as a wildcard and expands it via `GetAllTypes()`, producing catch-all entries that can overwrite earlier, correct registrations (e.g. `min:date` registered under `functions_datetime` gets overwritten with the `unknown` URN).
2. **Bogus URNs / fabricated signatures:** these functions carried the placeholder URN `extension:io.substrait:unknown` and produced names like `multiply:any_any` / `sum:any` that correspond to no real declared signature.

## Fix

Make extension selection explicit: allowlist by the `functions_*.yaml` naming convention, mirroring substrait-java. This skips:

- example/placeholder extensions (`unknown.yaml`), and
- type-only definitions (`extension_types.yaml`, `type_variations.yaml`) that declare no functions.

Type combinations not covered by a real extension now correctly fall back to `native` instead of referencing a fake URN. `functions_geometry` and `functions_aggregate_decimal_output` remain ingested, as requested in the issue. Skipped files are logged during generation for transparency.

`src/custom_extensions_generated.cpp` was regenerated from `substrait-packaging` tag `cpp/substrait-extensions/v0.94.0` (already pinned in the script). The only change is the removal of the 10 bogus `extension:io.substrait:unknown` registrations.

## Follow-up cleanup

With the generator no longer emitting any `unknown` argument type (and `TransformTypes()` never producing `"unknown"` — the placeholder is a user-defined type at runtime), the `t == "unknown"` expansion branch in `InsertCustomFunction` was unreachable. It and the stale comment reference are removed.

## Latent bug surfaced by dropping `unknown.yaml`

Removing `unknown.yaml` exposed a bug it had been masking. The aggregate `sum`/`avg`/`min`/`max` in `functions_arithmetic_decimal` spell their argument `DECIMAL` (uppercase), while `TransformTypes()` only ever yields the lowercase proto kind name `decimal` at lookup — so those overloads never resolved on their own. The `unknown` catch-all (expanded over `GetAllTypes()`, which includes lowercase `decimal`) was silently standing in for them, which is why e.g. TPC-H Q1 (`sum`/`avg` over decimal) passed before.

This PR normalizes the declared `DECIMAL` → `decimal` alongside the existing spelling normalizations (`boolean`→`bool`, `fixedchar`→`fixed_char`, …), so `sum`/`avg`/`min`/`max` over decimal now resolve to the real `functions_arithmetic_decimal` URN. This closes the `avg:dec` resolution gap that was documented as a known follow-up in `test/c/test_projection.cpp` (its expected JSON and note are updated accordingly).

## Testing

- `build/release/test/unittest 'test/sql/*'` → all pass (49 cases, 1293 assertions; 1 httpfs skip).
- C API tests (`test_substrait_exe`) → all pass (48 cases, 255 assertions; 1 skip).
- The previously-failing `test/sql/test_substrait_tpch.test` (strict-mode `sum`/`avg` over decimal) now passes.

🤖 Generated with AI