### PR TITLE
feat: implement support for missing Substrait literal types

### DIFF
--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -104,6 +104,31 @@ SubstraitToDuckDB::SubstraitToDuckDB(shared_ptr<ClientContext> &context_p, const
 	}
 }
 
+static const int64_t POWERS_OF_10[] = {
+	1LL,
+	10LL,
+	100LL,
+	1000LL,
+	10000LL,
+	100000LL,
+	1000000LL,
+	10000000LL,
+	100000000LL,
+	1000000000LL
+};
+
+static int64_t ScaleToMicros(int64_t value, int32_t precision) {
+	if (precision < 0 || precision > 9) {
+		throw InvalidInputException("Precision must be between 0 and 9, got %d", precision);
+	}
+	if (precision > 6) {
+		return value / POWERS_OF_10[precision - 6];
+	} else if (precision < 6) {
+		return value * POWERS_OF_10[6 - precision];
+	}
+	return value;
+}
+
 Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 	if (literal.has_null()) {
 		return Value(LogicalType::SQLNULL);
@@ -148,6 +173,8 @@ Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 	}
 	case substrait::Expression_Literal::LiteralTypeCase::kI8:
 		return Value::TINYINT(static_cast<int8_t>(literal.i8()));
+	case substrait::Expression_Literal::LiteralTypeCase::kI16:
+		return Value::SMALLINT(static_cast<int16_t>(literal.i16()));
 	case substrait::Expression_Literal::LiteralTypeCase::kI32:
 		return Value::INTEGER(literal.i32());
 	case substrait::Expression_Literal::LiteralTypeCase::kI64:
@@ -162,7 +189,7 @@ Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 	}
 	case substrait::Expression_Literal::LiteralTypeCase::kIntervalYearToMonth: {
 		interval_t interval {};
-		interval.months = literal.interval_year_to_month().months();
+		interval.months = (int32_t)literal.interval_year_to_month().years() * 12 + literal.interval_year_to_month().months();
 		interval.days = 0;
 		interval.micros = 0;
 		return Value::INTERVAL(interval);
@@ -172,22 +199,121 @@ Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 		interval.months = 0;
 		interval.days = literal.interval_day_to_second().days();
 		// Convert seconds to microseconds and add subseconds (with precision adjustment)
-		int64_t seconds_in_micros = literal.interval_day_to_second().seconds() * Interval::MICROS_PER_SEC;
+		int64_t seconds_in_micros = (int64_t)literal.interval_day_to_second().seconds() * Interval::MICROS_PER_SEC;
 		int64_t subseconds = literal.interval_day_to_second().subseconds();
 		int32_t precision = literal.interval_day_to_second().precision();
-		// Adjust subseconds based on precision (e.g., precision 9 = nanoseconds, need to convert to microseconds)
-		if (precision > 6) {
-			// Convert from higher precision (e.g., nanoseconds) to microseconds
-			subseconds = subseconds / (int64_t)pow(10, precision - 6);
-		} else if (precision < 6) {
-			// Convert from lower precision (e.g., milliseconds) to microseconds
-			subseconds = subseconds * (int64_t)pow(10, 6 - precision);
-		}
+		subseconds = ScaleToMicros(subseconds, precision);
 		interval.micros = seconds_in_micros + subseconds;
 		return Value::INTERVAL(interval);
 	}
 	case substrait::Expression_Literal::LiteralTypeCase::kVarChar:
 		return {literal.var_char().value()};
+	case substrait::Expression_Literal::LiteralTypeCase::kFixedChar:
+		return {literal.fixed_char()};
+	case substrait::Expression_Literal::LiteralTypeCase::kBinary: {
+		const auto &binary_data = literal.binary();
+		return Value::BLOB(const_data_ptr_cast(binary_data.data()), binary_data.size());
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kFixedBinary: {
+		const auto &binary_data = literal.fixed_binary();
+		return Value::BLOB(const_data_ptr_cast(binary_data.data()), binary_data.size());
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kPrecisionTimestamp: {
+		int64_t timestamp_value = literal.precision_timestamp().value();
+		int32_t precision = literal.precision_timestamp().precision();
+		int64_t micros = ScaleToMicros(timestamp_value, precision);
+		timestamp_t ts(micros);
+		return Value::TIMESTAMP(ts);
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kPrecisionTimestampTz: {
+		int64_t timestamp_value = literal.precision_timestamp_tz().value();
+		int32_t precision = literal.precision_timestamp_tz().precision();
+		int64_t micros = ScaleToMicros(timestamp_value, precision);
+		timestamp_tz_t ts(micros);
+		return Value::TIMESTAMPTZ(ts);
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kUuid: {
+		const auto &uuid_bytes = literal.uuid();
+		if (uuid_bytes.size() != 16) {
+			throw InvalidInputException("UUID value must be exactly 16 bytes, but has " + std::to_string(uuid_bytes.size()));
+		}
+		return Value::BLOB(const_data_ptr_cast(uuid_bytes.data()), 16);
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kStruct: {
+		// For struct literals, handle empty struct as NULL
+		const auto &struct_lit = literal.struct_();
+		if (struct_lit.fields_size() == 0) {
+			return Value(LogicalType::SQLNULL);
+		}
+		child_list_t<Value> field_values;
+		for (int i = 0; i < struct_lit.fields_size(); i++) {
+			auto field_name = "f" + std::to_string(i);
+			field_values.push_back(make_pair(field_name, TransformLiteralToValue(struct_lit.fields(i))));
+		}
+		return Value::STRUCT(field_values);
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kMap: {
+		// For map literals, convert to a DuckDB map
+		vector<Value> keys;
+		vector<Value> values;
+		const auto &map_lit = literal.map();
+		for (const auto &kv : map_lit.key_values()) {
+			keys.push_back(TransformLiteralToValue(kv.key()));
+			values.push_back(TransformLiteralToValue(kv.value()));
+		}
+		// Infer key and value types from the first element, or use VARCHAR/VARCHAR for empty maps
+		LogicalType key_type = LogicalType::VARCHAR;
+		LogicalType value_type = LogicalType::VARCHAR;
+		if (!keys.empty()) {
+			key_type = keys[0].type();
+			value_type = values[0].type();
+		}
+		return Value::MAP(key_type, value_type, keys, values);
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kList: {
+		// For list literals, convert to a DuckDB list
+		vector<Value> list_values;
+		const auto &list_lit = literal.list();
+		for (const auto &elem : list_lit.values()) {
+			list_values.push_back(TransformLiteralToValue(elem));
+		}
+		// Infer element type from first element or use VARCHAR for empty lists
+		LogicalType element_type = LogicalType::VARCHAR;
+		if (!list_values.empty()) {
+			element_type = list_values[0].type();
+		}
+		return Value::LIST(element_type, list_values);
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kEmptyList: {
+		// Empty list - create a list with null type
+		vector<Value> empty_values;
+		return Value::LIST(LogicalType::SQLNULL, empty_values);
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kEmptyMap: {
+		// Empty map - create with default types
+		vector<Value> empty_keys;
+		vector<Value> empty_values;
+		return Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, empty_keys, empty_values);
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kIntervalCompound: {
+		// Combine year-to-month and day-to-second intervals
+		interval_t interval {};
+		const auto &compound = literal.interval_compound();
+		if (compound.has_interval_year_to_month()) {
+			interval.months = compound.interval_year_to_month().years() * 12 + compound.interval_year_to_month().months();
+		}
+		if (compound.has_interval_day_to_second()) {
+			interval.days = compound.interval_day_to_second().days();
+			int64_t seconds_in_micros = (int64_t)compound.interval_day_to_second().seconds() * Interval::MICROS_PER_SEC;
+			int64_t subseconds = compound.interval_day_to_second().subseconds();
+			int32_t precision = compound.interval_day_to_second().precision();
+			subseconds = ScaleToMicros(subseconds, precision);
+			interval.micros = seconds_in_micros + subseconds;
+		}
+		return Value::INTERVAL(interval);
+	}
+	case substrait::Expression_Literal::LiteralTypeCase::kUserDefined:
+		throw NotImplementedException("User-defined literals are not supported");
 	default:
 		throw NotImplementedException(
 		    "literals of this type are not implemented: %s",

--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -129,6 +129,15 @@ static int64_t ScaleToMicros(int64_t value, int32_t precision) {
 	return value;
 }
 
+static int64_t DayToSecondMicros(int32_t seconds, int64_t subseconds, int32_t precision) {
+	int64_t seconds_in_micros = (int64_t)seconds * Interval::MICROS_PER_SEC;
+	return seconds_in_micros + ScaleToMicros(subseconds, precision);
+}
+
+static int32_t YearToMonthMonths(int32_t years, int32_t months) {
+	return years * 12 + months;
+}
+
 Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 	if (literal.has_null()) {
 		return Value(LogicalType::SQLNULL);
@@ -189,7 +198,7 @@ Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 	}
 	case substrait::Expression_Literal::LiteralTypeCase::kIntervalYearToMonth: {
 		interval_t interval {};
-		interval.months = (int32_t)literal.interval_year_to_month().years() * 12 + literal.interval_year_to_month().months();
+		interval.months = YearToMonthMonths(literal.interval_year_to_month().years(), literal.interval_year_to_month().months());
 		interval.days = 0;
 		interval.micros = 0;
 		return Value::INTERVAL(interval);
@@ -198,12 +207,9 @@ Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 		interval_t interval {};
 		interval.months = 0;
 		interval.days = literal.interval_day_to_second().days();
-		// Convert seconds to microseconds and add subseconds (with precision adjustment)
-		int64_t seconds_in_micros = (int64_t)literal.interval_day_to_second().seconds() * Interval::MICROS_PER_SEC;
-		int64_t subseconds = literal.interval_day_to_second().subseconds();
-		int32_t precision = literal.interval_day_to_second().precision();
-		subseconds = ScaleToMicros(subseconds, precision);
-		interval.micros = seconds_in_micros + subseconds;
+		interval.micros = DayToSecondMicros(literal.interval_day_to_second().seconds(),
+		                                    literal.interval_day_to_second().subseconds(),
+		                                    literal.interval_day_to_second().precision());
 		return Value::INTERVAL(interval);
 	}
 	case substrait::Expression_Literal::LiteralTypeCase::kVarChar:
@@ -237,12 +243,15 @@ Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 		if (uuid_bytes.size() != 16) {
 			throw InvalidInputException("UUID value must be exactly 16 bytes, but has " + std::to_string(uuid_bytes.size()));
 		}
+		// Note: UUID literals are returned as BLOB values. When a typed schema declares a UUID
+		// column, the BLOB literal will need an implicit BLOB→UUID cast for round-tripping
+		// through a virtualTable read, which DuckDB does not provide. This is a known limitation.
 		return Value::BLOB(const_data_ptr_cast(uuid_bytes.data()), 16);
 	}
 	case substrait::Expression_Literal::LiteralTypeCase::kStruct: {
-		// For struct literals, handle empty struct as NULL
 		const auto &struct_lit = literal.struct_();
 		if (struct_lit.fields_size() == 0) {
+			// DuckDB cannot represent a 0-field struct, so return NULL as a workaround
 			return Value(LogicalType::SQLNULL);
 		}
 		child_list_t<Value> field_values;
@@ -261,12 +270,23 @@ Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 			keys.push_back(TransformLiteralToValue(kv.key()));
 			values.push_back(TransformLiteralToValue(kv.value()));
 		}
-		// Infer key and value types from the first element, or use VARCHAR/VARCHAR for empty maps
+		// Infer key and value types from first non-null element, or default to VARCHAR
 		LogicalType key_type = LogicalType::VARCHAR;
 		LogicalType value_type = LogicalType::VARCHAR;
 		if (!keys.empty()) {
-			key_type = keys[0].type();
-			value_type = values[0].type();
+			// Skip leading NULL keys/values to find concrete types
+			for (idx_t i = 0; i < keys.size(); i++) {
+				if (keys[i].type() != LogicalType::SQLNULL) {
+					key_type = keys[i].type();
+					break;
+				}
+			}
+			for (idx_t i = 0; i < values.size(); i++) {
+				if (values[i].type() != LogicalType::SQLNULL) {
+					value_type = values[i].type();
+					break;
+				}
+			}
 		}
 		return Value::MAP(key_type, value_type, keys, values);
 	}
@@ -277,17 +297,24 @@ Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 		for (const auto &elem : list_lit.values()) {
 			list_values.push_back(TransformLiteralToValue(elem));
 		}
-		// Infer element type from first element or use VARCHAR for empty lists
+		// Infer element type from first non-null element, or default to VARCHAR
 		LogicalType element_type = LogicalType::VARCHAR;
 		if (!list_values.empty()) {
-			element_type = list_values[0].type();
+			// Skip NULL values to find a concrete type
+			for (const auto &val : list_values) {
+				if (val.type() != LogicalType::SQLNULL) {
+					element_type = val.type();
+					break;
+				}
+			}
+			// If all elements are NULL, use VARCHAR as default
 		}
 		return Value::LIST(element_type, list_values);
 	}
 	case substrait::Expression_Literal::LiteralTypeCase::kEmptyList: {
-		// Empty list - create a list with null type
+		// Empty list - use VARCHAR as default (consistent with empty kList)
 		vector<Value> empty_values;
-		return Value::LIST(LogicalType::SQLNULL, empty_values);
+		return Value::LIST(LogicalType::VARCHAR, empty_values);
 	}
 	case substrait::Expression_Literal::LiteralTypeCase::kEmptyMap: {
 		// Empty map - create with default types
@@ -300,15 +327,14 @@ Value TransformLiteralToValue(const substrait::Expression_Literal &literal) {
 		interval_t interval {};
 		const auto &compound = literal.interval_compound();
 		if (compound.has_interval_year_to_month()) {
-			interval.months = compound.interval_year_to_month().years() * 12 + compound.interval_year_to_month().months();
+			interval.months = YearToMonthMonths(compound.interval_year_to_month().years(),
+			                                    compound.interval_year_to_month().months());
 		}
 		if (compound.has_interval_day_to_second()) {
 			interval.days = compound.interval_day_to_second().days();
-			int64_t seconds_in_micros = (int64_t)compound.interval_day_to_second().seconds() * Interval::MICROS_PER_SEC;
-			int64_t subseconds = compound.interval_day_to_second().subseconds();
-			int32_t precision = compound.interval_day_to_second().precision();
-			subseconds = ScaleToMicros(subseconds, precision);
-			interval.micros = seconds_in_micros + subseconds;
+			interval.micros = DayToSecondMicros(compound.interval_day_to_second().seconds(),
+			                                    compound.interval_day_to_second().subseconds(),
+			                                    compound.interval_day_to_second().precision());
 		}
 		return Value::INTERVAL(interval);
 	}

--- a/test/sql/test_literals.test
+++ b/test/sql/test_literals.test
@@ -235,6 +235,12 @@ CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go
 ----
 {'f0': test, 'f1': [10, 20]}
 
+# valid 16-byte UUID (rendered as BLOB bytes)
+query I
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"uuid":"AAAAAAAAAAAAAAAAAAAAAA==", "nullable":true}}]}}, "names":["?column?"]}}]}')
+----
+\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00
+
 # user defined
 statement error
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"user_defined":{}, "nullable":true}}]}}, "names":["?column?"]}}]}')

--- a/test/sql/test_literals.test
+++ b/test/sql/test_literals.test
@@ -20,10 +20,10 @@ CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go
 123
 
 # i16
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"i16":123, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: i16
+123
 
 # i32
 query I
@@ -56,16 +56,16 @@ CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go
 abc
 
 # binary
-statement error
-CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"binary":"XDAwXDAxXDAy", "nullable":true}}]}}, "names":["?column?"]}}]}')
+query I
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"binary":"AAEC", "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: binary
+\x00\x01\x02
 
 # precision_timestamp
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"precision_timestamp":{"precision":6, "value":99999999}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: precision_timestamp
+1970-01-01 00:01:39.999999
 
 # date
 query I
@@ -79,11 +79,11 @@ CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go
 ----
 00:01:39.999999
 
-# interval year to month (wrong, should include be 38 months)
+# interval year to month
 query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"interval_year_to_month":{"years":3,"months":2}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-2 months
+3 years 2 months
 
 # interval day to second with subseconds and precision
 query I
@@ -91,23 +91,23 @@ CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go
 ----
 3 days 00:00:02.000023
 
-# interval day to second (precision) (wrong, should include subseconds)
+# interval day to second (precision 9 - nanoseconds)
 query I
-CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"interval_day_to_second":{"days":3,"seconds":2,"precision":9,"subseconds":23}, "nullable":true}}]}}, "names":["?column?"]}}]}')
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"interval_day_to_second":{"days":3,"seconds":2,"precision":9,"subseconds":23000}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-3 days 00:00:02
+3 days 00:00:02.000023
 
 # interval compound
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"interval_compound":{"interval_year_to_month":{"years":3,"months":2}, "interval_day_to_second":{"days":3,"seconds":2,"precision":9,"subseconds":23}}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: interval_compound
+3 years 2 months 3 days 00:00:02
 
 # fixed char
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"fixed_char":"abcd", "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: fixed_char
+abcd
 
 # var char
 query I
@@ -116,10 +116,10 @@ CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go
 abcd
 
 # fixed binary
-statement error
-CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"fixed_binary":"XDAwXDAxXDAy", "nullable":true}}]}}, "names":["?column?"]}}]}')
+query I
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"fixed_binary":"AAEC", "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: fixed_binary
+\x00\x01\x02
 
 # decimal invalid
 statement error
@@ -134,40 +134,40 @@ CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go
 1
 
 # precision timestamp
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"precision_timestamp":{"value":9999,"precision":3}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: precision_timestamp
+1970-01-01 00:00:09.999
 
 # precision timestamp tz
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"precision_timestamp_tz":{"value":9999,"precision":3}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: precision_timestamp_tz
+1970-01-01 00:00:09.999+00
 
 # struct
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"struct":{}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: struct
+NULL
 
 # map
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"map":{}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: map
+{}
 
 # precision_timestamp_tz
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"precisionTimestampTz":{"precision":6, "value":99999999}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: precision_timestamp_tz
+1970-01-01 00:01:39.999999+00
 
-# uuid
+# uuid (16-byte requirement enforced)
 statement error
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"uuid":"XDAwXDAxXDAy", "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: uuid
+Invalid Input Error: UUID value must be exactly 16 bytes, but has 9
 
 # null i8
 query I
@@ -176,25 +176,67 @@ CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go
 NULL
 
 # list
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"list":{}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: list
+[]
 
 # empty list
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"empty_list":{}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: empty_list
+[]
 
 # empty map
-statement error
+query I
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"empty_map":{}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: empty_map
+{}
+
+# non-empty list with integers
+query I
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"list":{"values":[{"i32":1},{"i32":2},{"i32":3}]}, "nullable":true}}]}}, "names":["?column?"]}}]}')
+----
+[1, 2, 3]
+
+# non-empty list with strings
+query I
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"list":{"values":[{"string":"a"},{"string":"b"}]}, "nullable":true}}]}}, "names":["?column?"]}}]}')
+----
+[a, b]
+
+# non-empty map with string keys and integer values
+query I
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"map":{"key_values":[{"key":{"string":"x"},"value":{"i32":10}},{"key":{"string":"y"},"value":{"i32":20}}]}, "nullable":true}}]}}, "names":["?column?"]}}]}')
+----
+{x=10, y=20}
+
+# non-empty struct with multiple types
+query I
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"struct":{"fields":[{"i32":42},{"string":"hello"},{"boolean":true}]}, "nullable":true}}]}}, "names":["?column?"]}}]}')
+----
+{'f0': 42, 'f1': hello, 'f2': true}
+
+# nested list (list of lists)
+query I
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"list":{"values":[{"list":{"values":[{"i32":1},{"i32":2}]}},{"list":{"values":[{"i32":3},{"i32":4}]}}]}, "nullable":true}}]}}, "names":["?column?"]}}]}')
+----
+[[1, 2], [3, 4]]
+
+# nested map (map with list values)
+query I
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"map":{"key_values":[{"key":{"string":"nums"},"value":{"list":{"values":[{"i32":1},{"i32":2},{"i32":3}]}}}]}, "nullable":true}}]}}, "names":["?column?"]}}]}')
+----
+{nums=[1, 2, 3]}
+
+# struct with nested list
+query I
+CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"struct":{"fields":[{"string":"test"},{"list":{"values":[{"i32":10},{"i32":20}]}}]}, "nullable":true}}]}}, "names":["?column?"]}}]}')
+----
+{'f0': test, 'f1': [10, 20]}
 
 # user defined
 statement error
 CALL from_substrait_json('{"version":{"minorNumber":29, "producer":"substrait-go"}, "relations":[{"root":{"input":{"project":{"common":{"direct":{}}, "input":{"read":{"common":{"direct":{}}, "baseSchema":{"struct":{"nullability":"NULLABILITY_REQUIRED"}}, "virtualTable":{"expressions":[{}]}}}, "expressions":[{"literal":{"user_defined":{}, "nullable":true}}]}}, "names":["?column?"]}}]}')
 ----
-Not implemented Error: literals of this type are not implemented: user_defined
+Not implemented Error: User-defined literals are not supported


### PR DESCRIPTION
Implement support for the following unimplemented literal types in Substrait to DuckDB conversion:
- i16 (signed 16-bit integer)
- binary and fixed_binary
- precision_timestamp and precision_timestamp_tz
- uuid
- fixed_char
- struct, map, list, empty_list, empty_map
- interval_compound

Update test_literals.test to mark these types as supported with expected outputs.
Add extra tests (non-empty lists, maps, structs) for full coverage. User-defined literals are currently unsupported.

Assisted by AI.