### PR TITLE
build: update substrait to 0.97.0

### DIFF
--- a/scripts/generate_custom_functions.py
+++ b/scripts/generate_custom_functions.py
@@ -13,7 +13,7 @@ import regex
 # version, then re-run this script and commit the regenerated
 # src/custom_extensions_generated.cpp.
 SUBSTRAIT_PACKAGING_REPO = "https://github.com/substrait-io/substrait-packaging.git"
-SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.96.0"
+SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.97.0"
 SUBSTRAIT_EXTENSIONS_SUBDIR = os.path.join("cpp", "substrait-extensions", "extensions")
 
 # Only ingest extension YAMLs that declare real Substrait functions. Every

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -4,7 +4,7 @@
             "kind": "git",
             "repository": "https://github.com/substrait-io/substrait-packaging",
             "reference": "vcpkg-registry",
-            "baseline": "ecc4c619c77d38b88326b1c1e10102fb07c70252",
+            "baseline": "647b70bfd0b3859e29de2abafff9bec9881e6f29",
             "packages": [
                 "substrait-protobuf",
                 "substrait-extensions",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,7 @@
     "overrides": [
         {
             "name": "substrait-protobuf",
-            "version": "0.96.0"
+            "version": "0.97.0"
         }
     ]
 }


### PR DESCRIPTION
Substrate 0.97.0 contains a breaking change whereby `IntervalDay.precision` _must_ be explicitly set by producers.
It is confirmed that this extension already satisfies that condition.

Resolves #223 