### PR TITLE
build: fix Substrait 0.98.0 breaking API changes

### DIFF
--- a/scripts/generate_custom_functions.py
+++ b/scripts/generate_custom_functions.py
@@ -13,7 +13,7 @@ import regex
 # version, then re-run this script and commit the regenerated
 # src/custom_extensions_generated.cpp.
 SUBSTRAIT_PACKAGING_REPO = "https://github.com/substrait-io/substrait-packaging.git"
-SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.97.0"
+SUBSTRAIT_EXTENSIONS_TAG = "cpp/substrait-extensions/v0.98.0"
 SUBSTRAIT_EXTENSIONS_SUBDIR = os.path.join("cpp", "substrait-extensions", "extensions")
 
 # Only ingest extension YAMLs that declare real Substrait functions. Every

--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -199,6 +199,17 @@ unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformLiteralExpr(const subst
 	return make_uniq<ConstantExpression>(TransformLiteralToValue(sexpr.literal()));
 }
 
+static idx_t ExtractLiteralInteger(const substrait::Expression &expr, const char *context_desc) {
+	if (!expr.has_literal()) {
+		throw NotImplementedException("Non-literal expressions in %s are not supported", context_desc);
+	}
+	auto val = TransformLiteralToValue(expr.literal());
+	if (val.IsNull()) {
+		throw NotImplementedException("NULL expressions in %s are not supported", context_desc);
+	}
+	return val.GetValue<int64_t>();
+}
+
 unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformSelectionExpr(const substrait::Expression &sexpr) {
 	if (!sexpr.selection().has_direct_reference() || !sexpr.selection().direct_reference().has_struct_field()) {
 		throw SyntaxException("Can only have direct struct references in selections");
@@ -630,8 +641,17 @@ shared_ptr<Relation> SubstraitToDuckDB::TransformCrossProductOp(const substrait:
 shared_ptr<Relation> SubstraitToDuckDB::TransformFetchOp(const substrait::Rel &sop,
                                                          const google::protobuf::RepeatedPtrField<std::string> *names) {
 	auto &slimit = sop.fetch();
-	idx_t limit = slimit.count() == -1 ? NumericLimits<idx_t>::Maximum() : slimit.count();
-	idx_t offset = slimit.offset();
+
+	idx_t limit = NumericLimits<idx_t>::Maximum();
+	if (slimit.has_count_expr()) {
+		limit = ExtractLiteralInteger(slimit.count_expr(), "LIMIT count");
+	}
+
+	idx_t offset = 0;
+	if (slimit.has_offset_expr()) {
+		offset = ExtractLiteralInteger(slimit.offset_expr(), "LIMIT offset");
+	}
+
 	return make_shared_ptr<LimitRelation>(TransformOp(slimit.input(), names), limit, offset);
 }
 
@@ -711,7 +731,7 @@ SubstraitToDuckDB::TransformProjectOp(const substrait::Rel &sop,
 		auto &sget = sop.project().input().read();
 		if (sget.has_virtual_table()) {
 			auto virtual_table = sget.virtual_table();
-			if ((virtual_table.values().empty() && virtual_table.expressions().empty()) ||
+			if ((virtual_table.expressions().empty()) ||
 			    (virtual_table.expressions().size() > 0 && virtual_table.expressions(0).fields().empty())) {
 				hasZeroColumnVirtualTable = true;
 				input_rel = GetValueRelationWithSingleBoolColumn();
@@ -927,14 +947,18 @@ shared_ptr<Relation> SubstraitToDuckDB::TransformReadOp(const substrait::Rel &so
 		scan = rel->Alias(name);
 	} else if (sget.has_virtual_table()) {
 		// We need to handle a virtual table as a LogicalExpressionGet
-		if (!sget.virtual_table().values().empty()) {
-			auto literal_values = sget.virtual_table().values();
+		if (!sget.virtual_table().expressions().empty()) {
+			auto literal_values = sget.virtual_table().expressions();
 			vector<vector<Value>> expression_rows;
 			for (auto &row : literal_values) {
 				auto values = row.fields();
 				vector<Value> expression_row;
 				for (const auto &value : values) {
-					expression_row.emplace_back(TransformLiteralToValue(value));
+					if (value.has_literal()) {
+						expression_row.emplace_back(TransformLiteralToValue(value.literal()));
+					} else {
+						throw NotImplementedException("Non-literal expressions in virtual table values are not supported");
+					}
 				}
 				expression_rows.emplace_back(expression_row);
 			}

--- a/src/from_substrait.cpp
+++ b/src/from_substrait.cpp
@@ -207,7 +207,11 @@ static idx_t ExtractLiteralInteger(const substrait::Expression &expr, const char
 	if (val.IsNull()) {
 		throw NotImplementedException("NULL expressions in %s are not supported", context_desc);
 	}
-	return val.GetValue<int64_t>();
+	auto int_val = val.GetValue<int64_t>();
+	if (int_val < 0) {
+		throw InvalidInputException("Negative values in %s are not supported", context_desc);
+	}
+	return int_val;
 }
 
 unique_ptr<ParsedExpression> SubstraitToDuckDB::TransformSelectionExpr(const substrait::Expression &sexpr) {
@@ -948,28 +952,6 @@ shared_ptr<Relation> SubstraitToDuckDB::TransformReadOp(const substrait::Rel &so
 	} else if (sget.has_virtual_table()) {
 		// We need to handle a virtual table as a LogicalExpressionGet
 		if (!sget.virtual_table().expressions().empty()) {
-			auto literal_values = sget.virtual_table().expressions();
-			vector<vector<Value>> expression_rows;
-			for (auto &row : literal_values) {
-				auto values = row.fields();
-				vector<Value> expression_row;
-				for (const auto &value : values) {
-					if (value.has_literal()) {
-						expression_row.emplace_back(TransformLiteralToValue(value.literal()));
-					} else {
-						throw NotImplementedException("Non-literal expressions in virtual table values are not supported");
-					}
-				}
-				expression_rows.emplace_back(expression_row);
-			}
-			vector<string> column_names;
-			if (acquire_lock) {
-				scan = make_shared_ptr<ValueRelation>(context, expression_rows, column_names);
-
-			} else {
-				scan = make_shared_ptr<ValueRelation>(context_wrapper, expression_rows, column_names);
-			}
-		} else if (!sget.virtual_table().expressions().empty()) {
 			scan = GetValuesExpression(sget.virtual_table().expressions());
 		} else if (sget.has_base_schema() && sget.base_schema().names_size() > 0 && sget.base_schema().struct_().types_size() > 0) {
 			// Empty virtual table represents an empty result (EMPTY_RESULT operator)

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -1079,12 +1079,12 @@ substrait::Rel *DuckDBToSubstrait::TransformTopN(LogicalOperator &dop) {
 
 	stopn->set_allocated_input(sord_rel.release());
 
-	// Set offset expression
+	// Set offset expression (always set, default is 0)
 	auto offset_expr = make_uniq<substrait::Expression>();
 	offset_expr->mutable_literal()->set_i64(static_cast<int64_t>(dtopn.offset));
 	stopn->set_allocated_offset_expr(offset_expr.release());
 
-	// Set count expression
+	// Set count expression (TopN always has a limit)
 	auto count_expr = make_uniq<substrait::Expression>();
 	count_expr->mutable_literal()->set_i64(static_cast<int64_t>(dtopn.limit));
 	stopn->set_allocated_count_expr(count_expr.release());
@@ -1122,15 +1122,17 @@ substrait::Rel *DuckDBToSubstrait::TransformLimit(LogicalOperator &dop) {
 	auto stopn = res->mutable_fetch();
 	stopn->set_allocated_input(TransformOp(*dop.children[0]));
 
-	// Set offset expression
+	// Set offset expression (always set, default is 0)
 	auto offset_expr = make_uniq<substrait::Expression>();
 	offset_expr->mutable_literal()->set_i64(static_cast<int64_t>(offset_val));
 	stopn->set_allocated_offset_expr(offset_expr.release());
 
-	// Set count expression
-	auto count_expr = make_uniq<substrait::Expression>();
-	count_expr->mutable_literal()->set_i64(static_cast<int64_t>(limit_val));
-	stopn->set_allocated_count_expr(count_expr.release());
+	// Set count expression only if limit is set (not -1)
+	if (limit_val >= 0) {
+		auto count_expr = make_uniq<substrait::Expression>();
+		count_expr->mutable_literal()->set_i64(static_cast<int64_t>(limit_val));
+		stopn->set_allocated_count_expr(count_expr.release());
+	}
 
 	return res.release();
 }

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -1078,8 +1078,17 @@ substrait::Rel *DuckDBToSubstrait::TransformTopN(LogicalOperator &dop) {
 	}
 
 	stopn->set_allocated_input(sord_rel.release());
-	stopn->set_offset(static_cast<int64_t>(dtopn.offset));
-	stopn->set_count(static_cast<int64_t>(dtopn.limit));
+
+	// Set offset expression
+	auto offset_expr = make_uniq<substrait::Expression>();
+	offset_expr->mutable_literal()->set_i64(static_cast<int64_t>(dtopn.offset));
+	stopn->set_allocated_offset_expr(offset_expr.release());
+
+	// Set count expression
+	auto count_expr = make_uniq<substrait::Expression>();
+	count_expr->mutable_literal()->set_i64(static_cast<int64_t>(dtopn.limit));
+	stopn->set_allocated_count_expr(count_expr.release());
+
 	return res.release();
 }
 
@@ -1113,8 +1122,16 @@ substrait::Rel *DuckDBToSubstrait::TransformLimit(LogicalOperator &dop) {
 	auto stopn = res->mutable_fetch();
 	stopn->set_allocated_input(TransformOp(*dop.children[0]));
 
-	stopn->set_offset(offset_val);
-	stopn->set_count(limit_val);
+	// Set offset expression
+	auto offset_expr = make_uniq<substrait::Expression>();
+	offset_expr->mutable_literal()->set_i64(static_cast<int64_t>(offset_val));
+	stopn->set_allocated_offset_expr(offset_expr.release());
+
+	// Set count expression
+	auto count_expr = make_uniq<substrait::Expression>();
+	count_expr->mutable_literal()->set_i64(static_cast<int64_t>(limit_val));
+	stopn->set_allocated_count_expr(count_expr.release());
+
 	return res.release();
 }
 
@@ -2029,8 +2046,9 @@ substrait::Rel *DuckDBToSubstrait::TransformDummyScan() {
 	auto virtual_table = sget->mutable_virtual_table();
 
 	// Add a dummy value to emit one row
-	auto dummy_struct = virtual_table->add_values();
-	dummy_struct->add_fields()->set_i32(42);
+	auto dummy_struct = virtual_table->add_expressions();
+	auto dummy_field = dummy_struct->add_fields();
+	dummy_field->mutable_literal()->set_i32(42);
 	return get_rel.release();
 }
 

--- a/test/c/test_projection.cpp
+++ b/test/c/test_projection.cpp
@@ -200,7 +200,7 @@ TEST_CASE("Test Project with bad plan", "[substrait-api]") {
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (1), (2), (3), (NULL)"));
 
 	// Plan with one column name and a project with 2 output columns (one input column, one expression) and with direct mapping
-	auto query_json =  R"({"relations":[{"root":{"input":{"project":{"input":{"fetch":{"input":{"read":{"baseSchema":{"names":["i"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"projection":{"select":{"structItems":[{}]},"maintainSingularStruct":true},"namedTable":{"names":["integers"]}}},"count":"5"}},"expressions":[{"selection":{"directReference":{"structField":{}},"rootReference":{}}}]}},"names":["i"]}}],"version":{"minorNumber":78,"producer":"DuckDB"}})";
+	auto query_json =  R"({"relations":[{"root":{"input":{"project":{"input":{"fetch":{"input":{"read":{"baseSchema":{"names":["i"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"projection":{"select":{"structItems":[{}]},"maintainSingularStruct":true},"namedTable":{"names":["integers"]}}},"countExpr":{"literal":{"i64":"5"}}}},"expressions":[{"selection":{"directReference":{"structField":{}},"rootReference":{}}}]}},"names":["i"]}}],"version":{"minorNumber":78,"producer":"DuckDB"}})";
 	auto exception_matcher = R"({"exception_type":"Invalid Input","exception_message":"Number of column names less than number of column definitions"})";
 	REQUIRE_THROWS_WITH(FromSubstraitJSON(con, query_json), exception_matcher);
 }
@@ -212,7 +212,7 @@ TEST_CASE("Test Project with duplicate columns", "[substrait-api]") {
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (1), (2), (3), (NULL)"));
 
-	auto query_json =  R"({"relations":[{"root":{"input":{"project":{"input":{"fetch":{"input":{"read":{"baseSchema":{"names":["i"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"projection":{"select":{"structItems":[{}]},"maintainSingularStruct":true},"namedTable":{"names":["integers"]}}},"count":"5"}},"expressions":[{"selection":{"directReference":{"structField":{}},"rootReference":{}}}]}},"names":["i", "integers"]}}],"version":{"minorNumber":78,"producer":"DuckDB"}})";
+	auto query_json =  R"({"relations":[{"root":{"input":{"project":{"input":{"fetch":{"input":{"read":{"baseSchema":{"names":["i"],"struct":{"types":[{"i32":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"projection":{"select":{"structItems":[{}]},"maintainSingularStruct":true},"namedTable":{"names":["integers"]}}},"countExpr":{"literal":{"i64":"5"}}}},"expressions":[{"selection":{"directReference":{"structField":{}},"rootReference":{}}}]}},"names":["i", "integers"]}}],"version":{"minorNumber":78,"producer":"DuckDB"}})";
 	auto res1 = FromSubstraitJSON(con, query_json);
 	REQUIRE(CHECK_COLUMN(res1, 0, {1, 2, 3, Value()}));
 	REQUIRE(CHECK_COLUMN(res1, 1, {1, 2, 3, Value()}));

--- a/test/c/test_substrait_c_api.cpp
+++ b/test/c/test_substrait_c_api.cpp
@@ -334,11 +334,13 @@ TEST_CASE_METHOD(DataDirectoryFixture, "Test C Function Varchar Literal", "[subs
 	                  "direct": {}
 	                },
 	                "virtualTable": {
-	                  "values": [
+	                  "expressions": [
 	                    {
 	                      "fields": [
 	                        {
-	                          "i32": 42
+	                          "literal": {
+	                            "i32": 42
+	                          }
 	                        }
 	                      ]
 	                    }
@@ -684,7 +686,7 @@ TEST_CASE("Test C Project SELECT 1", "[substrait-api]") {
 	DuckDB db(nullptr);
 	Connection con(db);
 
-	auto expected_json_str = R"({"relations":[{"root":{"input":{"project":{"common":{"emit":{"outputMapping":[1]}},"input":{"read":{"virtualTable":{"values":[{"fields":[{"i32":42}]}]}}},"expressions":[{"literal":{"i32":1}}]}},"names":["1"]}}],"version":{"minorNumber":78,"producer":"DuckDB"}})";
+	auto expected_json_str = R"({"relations":[{"root":{"input":{"project":{"common":{"emit":{"outputMapping":[1]}},"input":{"read":{"virtualTable":{"expressions":[{"fields":[{"literal":{"i32":42}}]}]}}},"expressions":[{"literal":{"i32":1}}]}},"names":["1"]}}],"version":{"minorNumber":78,"producer":"DuckDB"}})";
 	auto json_str = GetSubstraitJSON(con,"SELECT 1");
 	REQUIRE(json_str == expected_json_str);
 	auto result = FromSubstraitJSON(con,json_str);

--- a/test/sql/test_fetch_non_literal_expressions.test
+++ b/test/sql/test_fetch_non_literal_expressions.test
@@ -1,0 +1,82 @@
+# name: test/sql/test_fetch_non_literal_expressions.test
+# description: Test that non-literal expressions in FetchRel raise proper errors
+# group: [sql]
+
+require substrait
+
+# Test non-literal count expression (should fail)
+statement error
+CALL from_substrait_json('
+{
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "fetch": {
+            "input": {
+              "read": {
+                "baseSchema": {
+                  "names": ["a"],
+                  "struct": {
+                    "types": [{"i64": {"nullability": "NULLABILITY_NULLABLE"}}],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {"names": ["t"]}
+              }
+            },
+            "countExpr": {
+              "scalarFunction": {
+                "functionReference": 0,
+                "arguments": []
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "version": {"minorNumber": 52, "producer": "test"}
+}
+')
+----
+Non-literal expressions in LIMIT count are not supported
+
+# Test non-literal offset expression (should fail)
+statement error
+CALL from_substrait_json('
+{
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "fetch": {
+            "input": {
+              "read": {
+                "baseSchema": {
+                  "names": ["a"],
+                  "struct": {
+                    "types": [{"i64": {"nullability": "NULLABILITY_NULLABLE"}}],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {"names": ["t"]}
+              }
+            },
+            "offsetExpr": {
+              "scalarFunction": {
+                "functionReference": 0,
+                "arguments": []
+              }
+            },
+            "countExpr": {"literal": {"i64": "10"}}
+          }
+        }
+      }
+    }
+  ],
+  "version": {"minorNumber": 52, "producer": "test"}
+}
+')
+----
+Non-literal expressions in LIMIT offset are not supported

--- a/test/sql/test_named_table_resolution.test
+++ b/test/sql/test_named_table_resolution.test
@@ -15,7 +15,7 @@ INSERT INTO myschema.suppliers VALUES (1, 'Acme Corp'), (2, 'Widgets Ltd'), (3, 
 
 # 2-component: ["myschema", "suppliers"]
 query IT
-CALL from_substrait_json('{"relations":[{"root":{"input":{"fetch":{"input":{"read":{"baseSchema":{"names":["supplier_id","supplier_name"],"struct":{"types":[{"i64":{"nullability":"NULLABILITY_NULLABLE"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"projection":{"select":{"structItems":[{},{"field":1}]},"maintainSingularStruct":true},"namedTable":{"names":["myschema","suppliers"]}}},"offset":"0","count":"5"}},"names":["supplier_id","supplier_name"]}}],"version":{"minorNumber":78,"producer":"DuckDB"}}')
+CALL from_substrait_json('{"relations":[{"root":{"input":{"fetch":{"input":{"read":{"baseSchema":{"names":["supplier_id","supplier_name"],"struct":{"types":[{"i64":{"nullability":"NULLABILITY_NULLABLE"}},{"string":{"nullability":"NULLABILITY_NULLABLE"}}],"nullability":"NULLABILITY_REQUIRED"}},"projection":{"select":{"structItems":[{},{"field":1}]},"maintainSingularStruct":true},"namedTable":{"names":["myschema","suppliers"]}}},"offsetExpr":{"literal":{"i64":"0"}},"countExpr":{"literal":{"i64":"5"}}}},"names":["supplier_id","supplier_name"]}}],"version":{"minorNumber":78,"producer":"DuckDB"}}')
 ----
 1	Acme Corp
 2	Widgets Ltd

--- a/test/sql/test_nested_expressions.test
+++ b/test/sql/test_nested_expressions.test
@@ -171,7 +171,11 @@ CALL from_substrait_json('
                 ]
               }
             },
-            "count": 3
+            "countExpr": {
+              "literal": {
+                "i64": 3
+              }
+            }
           }
         },
         "names": [

--- a/test/sql/test_spark_gateway.test
+++ b/test/sql/test_spark_gateway.test
@@ -2351,7 +2351,11 @@ CALL from_substrait_json('
                 ]
               }
             },
-            "count": "5"
+            "countExpr": {
+              "literal": {
+                "i64": "5"
+              }
+            }
           }
         },
         "names": [

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -4,7 +4,7 @@
             "kind": "git",
             "repository": "https://github.com/substrait-io/substrait-packaging",
             "reference": "vcpkg-registry",
-            "baseline": "647b70bfd0b3859e29de2abafff9bec9881e6f29",
+            "baseline": "f15ab969466afd667afd985f98a521df77ede143",
             "packages": [
                 "substrait-protobuf",
                 "substrait-extensions",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,7 @@
     "overrides": [
         {
             "name": "substrait-protobuf",
-            "version": "0.97.0"
+            "version": "0.98.0"
         }
     ]
 }


### PR DESCRIPTION
Replace deprecated FetchRel setter methods with Expression-based API:
- set_offset/set_count → offset_expr/count_expr
- Extract integer values from expressions with has_literal() checks

Replace deprecated VirtualTable.values() with expressions():
- Use add_expressions() instead of add_values()
- Extract literals from Expression.fields() instead of direct access

Update test JSON format to use new expression-based API for FetchRel, with proper field naming for JSON deserialization (offsetExpr/countExpr).

Resolves #234 