### PR TITLE
fix: harden extension URN handling around the #205 fix

### DIFF
--- a/scripts/generate_custom_functions.py
+++ b/scripts/generate_custom_functions.py
@@ -58,8 +58,11 @@ def parse_function_data(functions,yaml_data,function_type):
 def parse_yaml(file_path):
 	with open(file_path, 'r') as file:
 		yaml_data = yaml.safe_load(file)
-	# `urn` is a required field in the Substrait simple-extensions schema.
+	# `urn` is a required field in the Substrait simple-extensions schema. Fail loudly rather than
+	# emitting an empty URN, which the producer cannot turn into a resolvable plan.
 	urn = yaml_data['urn']
+	if not isinstance(urn, str) or not urn.strip():
+		raise ValueError(f"{file_path}: 'urn' must be a non-empty string, got {urn!r}")
 	functions = []
 	functions = parse_function_data(functions,yaml_data,'scalar_functions')
 	functions = parse_function_data(functions,yaml_data,'aggregate_functions')

--- a/src/custom_extensions.cpp
+++ b/src/custom_extensions.cpp
@@ -49,8 +49,10 @@ vector<string> GetAllTypes() {
 }
 
 // Recurse over the whole shebang
+// `name` and `file_path` are deliberately const references: every leaf of this recursion needs
+// the same values, so moving out of them would empty the string for all subsequent leaves (see #205).
 void SubstraitCustomFunctions::InsertAllFunctions(const vector<vector<string>> &all_types, vector<idx_t> &indices,
-                                                  int depth, string &name, string &file_path) {
+                                                  int depth, const string &name, const string &file_path) {
 	if (depth == indices.size()) {
 		vector<string> types;
 		for (idx_t i = 0; i < indices.size(); i++) {
@@ -95,7 +97,8 @@ void SubstraitCustomFunctions::InsertAllFunctions(const vector<vector<string>> &
 	}
 }
 
-void SubstraitCustomFunctions::InsertCustomFunction(string name_p, vector<string> types_p, string file_path) {
+void SubstraitCustomFunctions::InsertCustomFunction(const string &name, vector<string> types_p,
+                                                    const string &file_path) {
 	auto types = std::move(types_p);
 	vector<vector<string>> all_types;
 	for (auto &t : types) {
@@ -112,7 +115,7 @@ void SubstraitCustomFunctions::InsertCustomFunction(string name_p, vector<string
 	vector<idx_t> idx(num_arguments, 0);
 
 	// Call the helper function with initial depth 0
-	InsertAllFunctions(all_types, idx, 0, name_p, file_path);
+	InsertAllFunctions(all_types, idx, 0, name, file_path);
 }
 
 // Maps a Substrait type name (the protobuf `Type.kind` oneof field name, e.g.
@@ -189,8 +192,7 @@ SubstraitFunctionExtensions SubstraitCustomFunctions::Get(const string &name,
 	vector<string> transformed_types;
 	if (types.empty()) {
 		SubstraitCustomFunction custom_function {name, {}};
-		auto it = any_arg_functions.find(custom_function);
-		if (it != custom_functions.end()) {
+		if (auto it = any_arg_functions.find(custom_function); it != any_arg_functions.end()) {
 			// We found it in our substrait custom map, return that
 			return it->second;
 		}

--- a/src/include/custom_extensions/custom_extensions.hpp
+++ b/src/include/custom_extensions/custom_extensions.hpp
@@ -79,9 +79,9 @@ private:
 	// When we have an argument ending with ? it means this argument can repeat many times
 	std::unordered_map<SubstraitCustomFunction, SubstraitFunctionExtensions, HashSubstraitFunctions> many_arg_functions;
 
-	void InsertCustomFunction(string name_p, vector<string> types_p, string file_path);
-	void InsertAllFunctions(const vector<vector<string>> &all_types, vector<idx_t> &indices, int depth, string &name_p,
-	                        string &file_path);
+	void InsertCustomFunction(const string &name, vector<string> types_p, const string &file_path);
+	void InsertAllFunctions(const vector<vector<string>> &all_types, vector<idx_t> &indices, int depth,
+	                        const string &name, const string &file_path);
 };
 
 } // namespace duckdb

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -626,6 +626,14 @@ uint64_t DuckDBToSubstrait::RegisterFunction(const string &name, vector<::substr
 	auto substrait_extensions = plan.mutable_extension_urns();
 	if (!function.IsNative()) {
 		auto extensionURN = function.GetExtensionURN();
+		if (extensionURN.empty()) {
+			// A non-native function must carry the URN declared by its extension YAML. An empty URN
+			// would be serialized as an extensionUrns entry with no `urn` field, and because
+			// extension_urn_map is keyed on the URN string, every such extension would collapse onto
+			// a single shared anchor -- silently producing an unresolvable plan (see #205, #212).
+			throw InternalException("Function \"%s\" resolved to an extension with an empty URN",
+			                        function.function.GetName());
+		}
 		auto it = extension_urn_map.find(extensionURN);
 		if (it == extension_urn_map.end()) {
 			// We have to add this extension

--- a/test/c/test_substrait_c_api.cpp
+++ b/test/c/test_substrait_c_api.cpp
@@ -808,11 +808,12 @@ TEST_CASE("Test cast to deprecated time type", "[substrait-api][deprecated-types
 	REQUIRE(CHECK_COLUMN(result, 0, {Value::TIME(10, 30, 0, 0)}));
 }
 
-TEST_CASE("Test extension URN for non-boolean comparison functions", "[substrait-api][extension-urn]") {
-	// Regression test: comparison functions registered with "any1" type expansion
-	// must have correct extension URNs for ALL type combinations, not just the first.
-	// Previously, std::move(file_path) in InsertAllFunctions emptied the path after
-	// the first type combo (bool_bool), leaving all others with a broken empty URN.
+TEST_CASE("Test extension URN for every any1-expanded overload", "[substrait-api][extension-urn]") {
+	// Regression test: a function declared `any1` is expanded over every concrete type kind, so one
+	// registration produces many overloads. All of them must carry the extension URN, not just the
+	// first one generated. Previously std::move(file_path) in InsertAllFunctions emptied the path
+	// after the first combination (bool_bool, bool being first in GetAllTypes()), so every later
+	// combination -- including i32_i32 below -- was left with an empty URN.
 	DuckDB db(nullptr);
 	Connection con(db);
 
@@ -821,7 +822,8 @@ TEST_CASE("Test extension URN for non-boolean comparison functions", "[substrait
 
 	auto json_str = GetSubstraitJSON(con, "SELECT * FROM t1 WHERE a = b");
 	REQUIRE(json_str.find("extension:io.substrait:functions_comparison") != string::npos);
-	REQUIRE(json_str.find("\"extension:io.substrait:\"") == string::npos);
+	// An empty URN is serialized as an anchor with no `urn` field, so that is the shape to exclude.
+	REQUIRE(json_str.find("{\"extensionUrnAnchor\":1}") == string::npos);
 
 	auto result = FromSubstraitJSON(con, json_str);
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));

--- a/test/sql/test_extension_urn.test
+++ b/test/sql/test_extension_urn.test
@@ -23,3 +23,20 @@ query I
 SELECT count(*) FROM get_substrait_json('SELECT sin(a) FROM t') WHERE contains("Json", '"urn":"extension:io.substrait:functions_arithmetic"')
 ----
 1
+
+# `count` and `sin` above are both registered with concrete argument types, so a single overload is
+# stored and any URN bug affecting later overloads cannot show up. `equal` is declared `any1, any1`
+# and is therefore expanded over every concrete type kind, producing many overloads from one
+# registration -- the case that regressed in #205. Every expanded overload must carry the URN, not
+# just the first one generated.
+query I
+SELECT count(*) FROM get_substrait_json('SELECT a = a FROM t') WHERE contains("Json", '"urn":"extension:io.substrait:functions_comparison"')
+----
+1
+
+# Guard the specific shape the #205 regression produced: an extensionUrns entry carrying an anchor
+# but no `urn` field, which is how an empty URN is serialized.
+query I
+SELECT count(*) FROM get_substrait_json('SELECT a = a FROM t') WHERE contains("Json", '{"extensionUrnAnchor":1}')
+----
+0


### PR DESCRIPTION
Follow-ups from reviewing #251. Four independent changes; none alters the plans the producer emits today.

**1. `Get()` compared an iterator from `any_arg_functions` against `custom_functions.end()`.** Undefined behaviour per [forward.iterators]/2, but it works by accident everywhere we build: the iterator type doesn't depend on the hasher (so it compiles), and both maps return a nullptr-based `end()` (so hit and miss both give the right answer). Worth fixing anyway — with `-D_GLIBCXX_DEBUG` it's a hard compile error, since `__gnu_debug::_Safe_iterator` is parameterised on the container type (confirmed with GCC 16).

**2. Empty extension URNs now throw instead of being emitted.** `IsNative()` only tests for the literal `"native"`, so an empty `extension_path` was treated as a real extension; since `extension_urn_map` is keyed on the URN string, every such extension collapsed onto one shared anchor. That is how #205 manifested. This guard was proposed in #212 and noted there as the one angle not tracked elsewhere; #205 then closed without it. The generator gets the matching check because it read `yaml_data['urn']` with no validation, so a YAML with a blank or missing `urn` would have produced `InsertCustomFunction(..., "")` — reachable input, given #214.

Unreachable with today's YAMLs (all 502 registrations carry a non-empty URN), so this is defence-in-depth.

**3. `const string &` on the parameters that carried the #205 bug.** These are read once per leaf of the `any`/`any1` expansion, so moving out of either empties it for every later leaf. `std::move(file_path)` was introduced **three separate times** (35d30d9, 9629478, b6520c2) before #251 removed it. Note this doesn't make the mistake impossible — `std::move` on a `const string &` still compiles, binding to the copy constructor — it makes it harmless, which is the property worth having.

**4. The regression assertion added in #251 could not fail.** With the bug, `extension_path` was *empty*, not the literal `"extension:io.substrait:"`, and protobuf omits empty string fields — so the plan read `{"extensionUrnAnchor":1}` and the asserted substring was absent either way. It looks like a leftover from before #210, when this same bug did render as that empty-id string. Replaced with a check for the shape that actually occurred, and `test_extension_urn.test` gains its first `any1`-expansion cases; its existing `count(*)`/`sin` cases are single-overload registrations that could not have caught #205. I checked each new assertion against a pre-#251 build to confirm it fails there rather than being vacuous like the one it replaces.

**Not included:** the `many_arg` classifier keys off the nullability marker `?` rather than the YAML's `variadic:` flag, which the generator discards — filed as #253, since fixing it changes all 502 generated registrations.

🤖 Generated with AI
