### PR TITLE
fix: stop ingesting functions_aggregate_decimal_output

### DIFF
--- a/scripts/generate_custom_functions.py
+++ b/scripts/generate_custom_functions.py
@@ -32,9 +32,31 @@ SUBSTRAIT_EXTENSIONS_SUBDIR = os.path.join("cpp", "substrait-extensions", "exten
 # fall back to `native` instead of referencing a fake URN.
 FUNCTION_EXTENSION_PREFIX = "functions_"
 
+# Function extensions this producer deliberately does not ingest, even though they match
+# the allowlist above.
+#
+# functions_aggregate_decimal_output declares `count` and `approx_count_distinct` returning
+# decimal<38,0>, differing from the standard aggregates only in return type. DuckDB's own
+# `count` and `approx_count_distinct` return BIGINT, so it has no overload that these
+# declarations could describe.
+#
+# Ingesting them is worse than redundant: they share (name, arg_types) with the i64
+# declarations in functions_aggregate_generic and functions_aggregate_approx, and the
+# overload maps in SubstraitCustomFunctions are keyed without an extension component, so
+# only one declaration per key can be held. Excluding this file keeps each of those names
+# bound to the extension whose return type DuckDB actually implements.
+#
+# Upstream discussion of whether this extension should exist at all:
+# https://github.com/substrait-io/substrait/issues/1121
+EXCLUDED_FUNCTION_EXTENSIONS = frozenset({"functions_aggregate_decimal_output.yaml"})
+
 
 def is_function_extension(file_name):
 	return file_name.startswith(FUNCTION_EXTENSION_PREFIX) and file_name.endswith(".yaml")
+
+
+def is_excluded_function_extension(file_name):
+	return file_name in EXCLUDED_FUNCTION_EXTENSIONS
 
 
 def parse_function_data(functions,yaml_data,function_type):
@@ -76,6 +98,9 @@ def get_custom_functions(custom_extension_folder):
 	for custom_function_path in custom_function_paths:
 		if not is_function_extension(custom_function_path):
 			print(f"Skipping non-function extension YAML: {custom_function_path}")
+			continue
+		if is_excluded_function_extension(custom_function_path):
+			print(f"Skipping unsupported extension YAML: {custom_function_path}")
 			continue
 		# Each extension YAML declares its own Substrait URN
 		# (extension:<owner>:<id>); use it directly rather than reconstructing it

--- a/src/custom_extensions_generated.cpp
+++ b/src/custom_extensions_generated.cpp
@@ -138,9 +138,6 @@ void SubstraitCustomFunctions::Initialize() {
 	InsertCustomFunction("centroid", {"u!geometry"}, "extension:io.substrait:functions_geometry");
 	InsertCustomFunction("minimum_bounding_circle", {"u!geometry"}, "extension:io.substrait:functions_geometry");
 	InsertCustomFunction("approx_count_distinct", {"any"}, "extension:io.substrait:functions_aggregate_approx");
-	InsertCustomFunction("count", {"any"}, "extension:io.substrait:functions_aggregate_decimal_output");
-	InsertCustomFunction("count", {}, "extension:io.substrait:functions_aggregate_decimal_output");
-	InsertCustomFunction("approx_count_distinct", {"any"}, "extension:io.substrait:functions_aggregate_decimal_output");
 	InsertCustomFunction("ceil", {"decimal"}, "extension:io.substrait:functions_rounding_decimal");
 	InsertCustomFunction("floor", {"decimal"}, "extension:io.substrait:functions_rounding_decimal");
 	InsertCustomFunction("round", {"decimal", "i32"}, "extension:io.substrait:functions_rounding_decimal");

--- a/test/sql/test_extension_urn.test
+++ b/test/sql/test_extension_urn.test
@@ -40,3 +40,20 @@ query I
 SELECT count(*) FROM get_substrait_json('SELECT a = a FROM t') WHERE contains("Json", '{"extensionUrnAnchor":1}')
 ----
 0
+
+# `approx_count_distinct` is declared by two extensions -- returning i64 in
+# functions_aggregate_approx and decimal<38,0> in functions_aggregate_decimal_output -- and the
+# overload maps are keyed on (name, arg_types) with no extension component, so only one of them can
+# be held per key. DuckDB's approx_count_distinct returns BIGINT, so functions_aggregate_approx is
+# the correct attribution.
+query I
+SELECT count(*) FROM get_substrait_json('SELECT approx_count_distinct(a) FROM t') WHERE contains("Json", '"urn":"extension:io.substrait:functions_aggregate_approx"')
+----
+1
+
+# The decimal-output extension is not ingested, so its URN must never appear in an emitted plan.
+# `count` is declared by it as well, and must stay bound to functions_aggregate_generic.
+query I
+SELECT count(*) FROM get_substrait_json('SELECT approx_count_distinct(a), count(a) FROM t') WHERE contains("Json", 'functions_aggregate_decimal_output')
+----
+0


### PR DESCRIPTION
Stops ingesting `functions_aggregate_decimal_output.yaml`, which declares `count` and `approx_count_distinct` returning `decimal<38,0>`. DuckDB has no such overloads — both of its functions return `BIGINT` — so those declarations describe functions this extension can never emit.

They were also actively harmful. The overload maps in `SubstraitCustomFunctions` are keyed on `(name, arg_types)` with **no extension component**, so two same-named functions from different extensions cannot both be represented; a later registration silently overwrites an earlier one and attribution comes down to generated-file order:

```
140: approx_count_distinct(any) -> functions_aggregate_approx
143: approx_count_distinct(any) -> functions_aggregate_decimal_output   <- overwrites 140
482: count(any)                 -> functions_aggregate_generic          <- overwrites 141
483: count()                    -> functions_aggregate_generic          <- overwrites 142
```

`count` happened to land on the correct extension; `approx_count_distinct` did not. Before this change, `SELECT approx_count_distinct(i)` emitted `extension:io.substrait:functions_aggregate_decimal_output` for a function DuckDB types as `BIGINT`.

Excluding the file is free: it declares only three impls under two names, and every one is declared elsewhere by an `i64` variant that matches DuckDB (`functions_aggregate_generic`, `functions_aggregate_approx`). Nothing falls back to `native`, and `count` is unaffected because it already resolved to generic. Those three keys were the **only** cross-extension collisions in the generated output, so this removes the ambiguity rather than resolving it by accident — verified zero remain afterwards.

Chose exclusion over teaching the lookup to disambiguate by return type because it eliminates the collision class instead of adding logic to arbitrate it. If substrait-io/substrait#1121 lands and the extension is dropped upstream, this exclusion simply becomes a no-op.

Two notes for reviewers:

- Nothing covered `approx_count_distinct`'s URN before, which is why the wrong attribution passed silently. `test/sql/test_extension_urn.test` now asserts the correct extension and that the decimal-output URN never appears.
- #254's `duckdb_dialect.yaml` declares an `aggregate_decimal_output` alias that no function entry references. It should be dropped there too, so the dialect spec and the generator agree on what this extension supports.

`src/custom_extensions_generated.cpp` is checked in and there is no CI check that it matches the generator, so it is regenerated here by hand (502 -> 499 registrations, the three removed lines being the only change).

🤖 Generated with AI
