### PR TITLE
fix: emit the de-facto `name:` form for zero-argument functions (#258)

### DIFF
--- a/src/custom_extensions.cpp
+++ b/src/custom_extensions.cpp
@@ -25,7 +25,7 @@ string TransformTypes(const substrait::Type &type) {
 // pre-building the overload maps. Each token is a protobuf Type.kind field name
 // (what TransformTypes() derives from a concrete argument), so the expanded
 // overloads match at lookup -- these are proto kind names, not the abbreviated
-// signature short names GetName() emits. This is the curated set of kinds that
+// signature short names GetCompoundName() emits. This is the curated set of kinds that
 // occur as arguments, not an exhaustive list of every proto kind.
 vector<string> GetAllTypes() {
 	return {{"bool"},
@@ -211,16 +211,10 @@ static string TypeShortName(const string &type) {
 // `count:`, not `count`. The signature grammar cannot actually express that case
 // (`argument-signature` requires at least one short-arg-type, filed upstream as
 // substrait-io/substrait#1162), so `name:` is a de-facto convention rather than a
-// normative one. It is however what all three reference producers emit
-// (substrait-java's SimpleExtension.constructKey, substrait-go's expr/functions.go,
-// substrait-python's function_entry.py all append ':' unconditionally and then
-// join an empty argument list to the empty string) and what the spec's own dialect
-// tests assume, spelling zero-argument `rank` as `supported_impls: [""]`.
-//
-// It also matters for interop: substrait-java keys plan-side function lookup on
-// the emitted name verbatim while keying the registry side on constructKey(), so a
-// plan carrying a bare `count` matches nothing there and fails outright (see #258).
-string SubstraitCustomFunction::GetName() const {
+// normative one. It is however what the reference producers emit and what plan-side
+// function lookup expects of them, so a bare `count` fails to resolve. #258 has the
+// inventory and the reasoning.
+string SubstraitCustomFunction::GetCompoundName() const {
 	string function_signature = name + ":";
 	for (auto &type : arg_types) {
 		// A trailing '?' marks a nullable (variadic) argument in the declared
@@ -251,7 +245,7 @@ string SubstraitFunctionExtensions::GetName() const {
 	if (IsNative()) {
 		return function.name;
 	}
-	return function.GetName();
+	return function.GetCompoundName();
 }
 
 string SubstraitFunctionExtensions::GetExtensionURN() const {

--- a/src/custom_extensions.cpp
+++ b/src/custom_extensions.cpp
@@ -204,10 +204,23 @@ static string TypeShortName(const string &type) {
 	return it == SHORT_NAMES.end() ? type : it->second;
 }
 
-string SubstraitCustomFunction::GetName() {
-	if (arg_types.empty()) {
-		return name;
-	}
+// Builds the compound name of a declared impl: the function name, a ':', and the
+// short names of the declared argument types joined by '_'.
+//
+// An impl declared with no arguments keeps the ':' with nothing after it --
+// `count:`, not `count`. The signature grammar cannot actually express that case
+// (`argument-signature` requires at least one short-arg-type, filed upstream as
+// substrait-io/substrait#1162), so `name:` is a de-facto convention rather than a
+// normative one. It is however what all three reference producers emit
+// (substrait-java's SimpleExtension.constructKey, substrait-go's expr/functions.go,
+// substrait-python's function_entry.py all append ':' unconditionally and then
+// join an empty argument list to the empty string) and what the spec's own dialect
+// tests assume, spelling zero-argument `rank` as `supported_impls: [""]`.
+//
+// It also matters for interop: substrait-java keys plan-side function lookup on
+// the emitted name verbatim while keying the registry side on constructKey(), so a
+// plan carrying a bare `count` matches nothing there and fails outright (see #258).
+string SubstraitCustomFunction::GetName() const {
 	string function_signature = name + ":";
 	for (auto &type : arg_types) {
 		// A trailing '?' marks a nullable (variadic) argument in the declared
@@ -217,8 +230,28 @@ string SubstraitCustomFunction::GetName() {
 		auto base = (!type.empty() && type.back() == '?') ? type.substr(0, type.size() - 1) : type;
 		function_signature += TypeShortName(base) + "_";
 	}
-	function_signature.pop_back();
+	if (!arg_types.empty()) {
+		// Drop the separator the last argument appended. Guarded, because a
+		// zero-argument impl never ran the loop and popping would eat the ':'.
+		function_signature.pop_back();
+	}
 	return function_signature;
+}
+
+// The name this function is declared under in the plan's extension list.
+//
+// A function that resolved against no extension YAML is emitted under its bare
+// DuckDB name, with no signature part at all: there is no declared impl to name it
+// after. That case is not distinguishable from the arg_types of the function alone,
+// because Get() reports it by returning empty arg_types no matter how many
+// arguments the call site had -- so the check has to happen here, where the
+// extension path is in scope. Hence the zero-argument native `random()` stays
+// `random` while the zero-argument declared `row_number()` becomes `row_number:`.
+string SubstraitFunctionExtensions::GetName() const {
+	if (IsNative()) {
+		return function.name;
+	}
+	return function.GetName();
 }
 
 string SubstraitFunctionExtensions::GetExtensionURN() const {

--- a/src/include/custom_extensions/custom_extensions.hpp
+++ b/src/include/custom_extensions/custom_extensions.hpp
@@ -22,7 +22,10 @@ struct SubstraitCustomFunction {
 	bool operator==(const SubstraitCustomFunction &other) const {
 		return name == other.name && arg_types == other.arg_types;
 	}
-	string GetName();
+	//! The compound name of this declared impl (name + ':' + declared arg short names).
+	//! Callers holding a SubstraitFunctionExtensions should prefer its GetName(), which
+	//! also handles functions that resolved against no extension.
+	string GetName() const;
 	string name;
 	vector<string> arg_types;
 };
@@ -33,6 +36,9 @@ public:
 	    : function(std::move(function_p)), extension_path(std::move(extension_path_p)) {};
 	SubstraitFunctionExtensions() = default;
 
+	//! The name to declare this function under: the impl's compound name, or the bare
+	//! function name when it resolved against no extension YAML.
+	string GetName() const;
 	string GetExtensionURN() const;
 	bool IsNative() const;
 

--- a/src/include/custom_extensions/custom_extensions.hpp
+++ b/src/include/custom_extensions/custom_extensions.hpp
@@ -23,9 +23,7 @@ struct SubstraitCustomFunction {
 		return name == other.name && arg_types == other.arg_types;
 	}
 	//! The compound name of this declared impl (name + ':' + declared arg short names).
-	//! Callers holding a SubstraitFunctionExtensions should prefer its GetName(), which
-	//! also handles functions that resolved against no extension.
-	string GetName() const;
+	string GetCompoundName() const;
 	string name;
 	vector<string> arg_types;
 };

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -632,7 +632,7 @@ uint64_t DuckDBToSubstrait::RegisterFunction(const string &name, vector<::substr
 			// extension_urn_map is keyed on the URN string, every such extension would collapse onto
 			// a single shared anchor -- silently producing an unresolvable plan (see #205, #212).
 			throw InternalException("Function \"%s\" resolved to an extension with an empty URN",
-			                        function.function.GetName());
+			                        function.GetName());
 		}
 		auto it = extension_urn_map.find(extensionURN);
 		if (it == extension_urn_map.end()) {
@@ -644,11 +644,11 @@ uint64_t DuckDBToSubstrait::RegisterFunction(const string &name, vector<::substr
 			last_urn_id++;
 		}
 	}
-	if (functions_map.find(function.function.GetName()) == functions_map.end()) {
+	if (functions_map.find(function.GetName()) == functions_map.end()) {
 		auto function_id = last_function_id++;
 		auto sfun = plan.add_extensions()->mutable_extension_function();
 		sfun->set_function_anchor(function_id);
-		sfun->set_name(function.function.GetName());
+		sfun->set_name(function.GetName());
 		if (!function.IsNative()) {
 			// We only define URN if not native
 			sfun->set_extension_urn_reference(extension_urn_map[function.GetExtensionURN()]);
@@ -659,7 +659,7 @@ uint64_t DuckDBToSubstrait::RegisterFunction(const string &name, vector<::substr
 				// Produce warning message
 				std::ostringstream error;
 				// Casting Error Message
-				error << "Could not find function \"" << function.function.GetName() << "\" with argument types: (";
+				error << "Could not find function \"" << function.GetName() << "\" with argument types: (";
 				auto types = SubstraitCustomFunctions::GetTypes(args_types);
 				for (idx_t i = 0; i < types.size(); i++) {
 					error << "\'" << types[i] << "\'";
@@ -671,9 +671,9 @@ uint64_t DuckDBToSubstrait::RegisterFunction(const string &name, vector<::substr
 				errors += error.str();
 			}
 		}
-		functions_map[function.function.GetName()] = function_id;
+		functions_map[function.GetName()] = function_id;
 	}
-	return functions_map[function.function.GetName()];
+	return functions_map[function.GetName()];
 }
 
 void DuckDBToSubstrait::CreateFieldRef(substrait::Expression *expr, uint64_t col_idx) {

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -623,6 +623,9 @@ uint64_t DuckDBToSubstrait::RegisterFunction(const string &name, vector<::substr
 		throw InternalException("Missing function name");
 	}
 	auto function = custom_functions.Get(name, args_types);
+	// The name the function is declared under: its impl's compound name, or the bare name
+	// when it resolved against no extension YAML. Every use below wants the same string.
+	const auto declared_name = function.GetName();
 	auto substrait_extensions = plan.mutable_extension_urns();
 	if (!function.IsNative()) {
 		auto extensionURN = function.GetExtensionURN();
@@ -631,8 +634,7 @@ uint64_t DuckDBToSubstrait::RegisterFunction(const string &name, vector<::substr
 			// would be serialized as an extensionUrns entry with no `urn` field, and because
 			// extension_urn_map is keyed on the URN string, every such extension would collapse onto
 			// a single shared anchor -- silently producing an unresolvable plan (see #205, #212).
-			throw InternalException("Function \"%s\" resolved to an extension with an empty URN",
-			                        function.GetName());
+			throw InternalException("Function \"%s\" resolved to an extension with an empty URN", declared_name);
 		}
 		auto it = extension_urn_map.find(extensionURN);
 		if (it == extension_urn_map.end()) {
@@ -644,11 +646,12 @@ uint64_t DuckDBToSubstrait::RegisterFunction(const string &name, vector<::substr
 			last_urn_id++;
 		}
 	}
-	if (functions_map.find(function.GetName()) == functions_map.end()) {
+	auto function_entry = functions_map.find(declared_name);
+	if (function_entry == functions_map.end()) {
 		auto function_id = last_function_id++;
 		auto sfun = plan.add_extensions()->mutable_extension_function();
 		sfun->set_function_anchor(function_id);
-		sfun->set_name(function.GetName());
+		sfun->set_name(declared_name);
 		if (!function.IsNative()) {
 			// We only define URN if not native
 			sfun->set_extension_urn_reference(extension_urn_map[function.GetExtensionURN()]);
@@ -659,7 +662,7 @@ uint64_t DuckDBToSubstrait::RegisterFunction(const string &name, vector<::substr
 				// Produce warning message
 				std::ostringstream error;
 				// Casting Error Message
-				error << "Could not find function \"" << function.GetName() << "\" with argument types: (";
+				error << "Could not find function \"" << declared_name << "\" with argument types: (";
 				auto types = SubstraitCustomFunctions::GetTypes(args_types);
 				for (idx_t i = 0; i < types.size(); i++) {
 					error << "\'" << types[i] << "\'";
@@ -671,9 +674,10 @@ uint64_t DuckDBToSubstrait::RegisterFunction(const string &name, vector<::substr
 				errors += error.str();
 			}
 		}
-		functions_map[function.GetName()] = function_id;
+		functions_map[declared_name] = function_id;
+		return function_id;
 	}
-	return functions_map[function.GetName()];
+	return function_entry->second;
 }
 
 void DuckDBToSubstrait::CreateFieldRef(substrait::Expression *expr, uint64_t col_idx) {

--- a/test/sql/test_custom_function.test
+++ b/test/sql/test_custom_function.test
@@ -135,4 +135,116 @@ CALL get_substrait_json('select a < b from t_4')
 ----
 <REGEX>:.*extension:io.substrait:functions_datetime.*
 
+# An impl declared with no arguments still gets the ':', with an empty signature
+# after it -- `count:`, not `count`. See #258: this is what the reference producers
+# emit, and substrait-java resolves a plan-side function by the emitted name
+# verbatim, so a bare `count` matches nothing there.
 
+query I
+CALL get_substrait_json('select count(*) from t_3')
+----
+<REGEX>:.*"count:".*
+
+# The five zero-argument window functions of functions_arithmetic are named the
+# same way
+
+query I
+CALL get_substrait_json('select row_number() over (order by a) from t_3')
+----
+<REGEX>:.*"row_number:".*
+
+query I
+CALL get_substrait_json('select rank() over (order by a) from t_3')
+----
+<REGEX>:.*"rank:".*
+
+query I
+CALL get_substrait_json('select dense_rank() over (order by a) from t_3')
+----
+<REGEX>:.*"dense_rank:".*
+
+query I
+CALL get_substrait_json('select percent_rank() over (order by a) from t_3')
+----
+<REGEX>:.*"percent_rank:".*
+
+query I
+CALL get_substrait_json('select cume_dist() over (order by a) from t_3')
+----
+<REGEX>:.*"cume_dist:".*
+
+query I
+CALL get_substrait_json('select row_number() over (order by a) from t_3')
+----
+<REGEX>:.*extension:io.substrait:functions_arithmetic.*
+
+# A function that resolved against no extension YAML has no declared signature to
+# name it after, so it keeps its bare name with no ':' at all. Get() reports that
+# case by returning an empty argument list whatever the call site passed -- md5 here
+# takes one argument and still arrives with none -- which is exactly what makes an
+# empty argument list on its own too weak to decide whether the ':' belongs. The
+# closing brace in the match is load-bearing twice over: it pins the name as bare
+# rather than `md5:`, and it shows the entry carries no extensionUrnReference.
+
+query I
+CALL get_substrait_json('select md5(a) from t_2')
+----
+<REGEX>:.*"name":"md5"\}.*
+
+# The compound name round-trips within this extension: RemoveExtension() truncates
+# at the first ':', so an ingested `count:` resolves to the record-counting count,
+# exactly as the bare `count` of test_substrait.test does.
+
+query I
+SELECT * FROM from_substrait_json('{
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "count:",
+        "extensionUrnReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "aggregate": {
+            "input": {
+              "read": {
+                "baseSchema": {
+                  "names": [ "a" ],
+                  "struct": {
+                    "types": [ { "i32": { "nullability": "NULLABILITY_NULLABLE" } } ],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": { "names": [ "t_3" ] }
+              }
+            },
+            "groupings": [ {} ],
+            "measures": [
+              {
+                "measure": {
+                  "functionReference": 1,
+                  "outputType": { "i64": { "nullability": "NULLABILITY_NULLABLE" } }
+                }
+              }
+            ]
+          }
+        },
+        "names": [ "c" ]
+      }
+    }
+  ],
+  "version": { "minorNumber": 78, "producer": "DuckDB" },
+  "extensionUrns": [
+    {
+      "extensionUrnAnchor": 1,
+      "urn": "extension:io.substrait:functions_aggregate_generic"
+    }
+  ]
+}')
+----
+2

--- a/test/sql/test_custom_function.test
+++ b/test/sql/test_custom_function.test
@@ -181,15 +181,18 @@ CALL get_substrait_json('select row_number() over (order by a) from t_3')
 # A function that resolved against no extension YAML has no declared signature to
 # name it after, so it keeps its bare name with no ':' at all. Get() reports that
 # case by returning an empty argument list whatever the call site passed -- md5 here
-# takes one argument and still arrives with none -- which is exactly what makes an
-# empty argument list on its own too weak to decide whether the ':' belongs. The
-# closing brace in the match is load-bearing twice over: it pins the name as bare
-# rather than `md5:`, and it shows the entry carries no extensionUrnReference.
+# takes one argument and still arrives with none -- which is what makes an empty
+# argument list on its own too weak to decide whether the ':' belongs.
 
 query I
 CALL get_substrait_json('select md5(a) from t_2')
 ----
-<REGEX>:.*"name":"md5"\}.*
+<REGEX>:.*"name":"md5".*
+
+query I
+CALL get_substrait_json('select md5(a) from t_2')
+----
+<!REGEX>:.*"md5:".*
 
 # The compound name round-trips within this extension: RemoveExtension() truncates
 # at the first ':', so an ingested `count:` resolves to the record-counting count,

--- a/test/sql/test_window.test
+++ b/test/sql/test_window.test
@@ -149,3 +149,79 @@ CALL get_substrait('WITH grouped AS (SELECT part1, part2, sum(val2) AS total_val
 
 statement ok
 CALL get_substrait('WITH sales AS (SELECT part1 AS category, part2 AS subcategory, sum(val) AS sales_amt FROM window_test_data GROUP BY part1, part2) SELECT category, subcategory, sales_amt, sales_amt * 100.0 / sum(sales_amt) OVER (PARTITION BY category) AS pct_in_category, row_number() OVER (PARTITION BY category ORDER BY sales_amt DESC, subcategory) AS sales_pos FROM sales')
+
+# Round-trip Tests
+#
+# Everything above is producer-only, so nothing here exercised the consumer side of
+# the five zero-argument window functions. Those reach DuckDB through
+# RemapFunctionName(), which truncates the emitted name at the first ':' before
+# matching it against WINDOW_ROW_NUMBER and friends -- so the `name:` form these are
+# emitted under since #258 depends on that truncation. Asserting the result values
+# rather than just the names locks in the semantics each name resolves to.
+#
+# from_substrait_json() rejects both an inline subquery and scalar use of
+# get_substrait_json(), hence the SET VARIABLE indirection.
+
+statement ok
+CREATE TABLE window_ties (a INTEGER)
+
+statement ok
+INSERT INTO window_ties VALUES (1), (2), (2), (5)
+
+statement ok
+SET VARIABLE plan_row_number = (SELECT json FROM get_substrait_json('SELECT a, row_number() OVER (ORDER BY a) AS r FROM window_ties'))
+
+query II
+SELECT * FROM from_substrait_json(getvariable('plan_row_number'))
+----
+1	1
+2	2
+2	3
+5	4
+
+# rank leaves a gap after a tie (1,2,2,4) where dense_rank does not (1,2,2,3), so the
+# two would be indistinguishable without the tie in the fixture
+
+statement ok
+SET VARIABLE plan_rank = (SELECT json FROM get_substrait_json('SELECT a, rank() OVER (ORDER BY a) AS r FROM window_ties'))
+
+query II
+SELECT * FROM from_substrait_json(getvariable('plan_rank'))
+----
+1	1
+2	2
+2	2
+5	4
+
+statement ok
+SET VARIABLE plan_dense_rank = (SELECT json FROM get_substrait_json('SELECT a, dense_rank() OVER (ORDER BY a) AS r FROM window_ties'))
+
+query II
+SELECT * FROM from_substrait_json(getvariable('plan_dense_rank'))
+----
+1	1
+2	2
+2	2
+5	3
+
+statement ok
+SET VARIABLE plan_percent_rank = (SELECT json FROM get_substrait_json('SELECT a, round(percent_rank() OVER (ORDER BY a), 3) AS r FROM window_ties'))
+
+query II
+SELECT * FROM from_substrait_json(getvariable('plan_percent_rank'))
+----
+1	0.0
+2	0.333
+2	0.333
+5	1.0
+
+statement ok
+SET VARIABLE plan_cume_dist = (SELECT json FROM get_substrait_json('SELECT a, round(cume_dist() OVER (ORDER BY a), 3) AS r FROM window_ties'))
+
+query II
+SELECT * FROM from_substrait_json(getvariable('plan_cume_dist'))
+----
+1	0.25
+2	0.75
+2	0.75
+5	1.0


### PR DESCRIPTION
Fixes #258, which carries the rationale: what the reference producers emit, what the spec's own dialect tests assume, and the substrait-java lookup failure that makes a bare `count` a concrete interop break rather than a cosmetic one. The grammar gap is filed upstream as substrait-io/substrait#1162; if that resolves to another spelling, one line changes here.

Six registrations were affected — the five zero-argument window functions of `functions_arithmetic`, and `count`'s record-counting impl.

## Why the change is split across two types

An empty argument list does not identify a zero-argument impl, so the compound-name builder cannot decide on its own whether the `:` belongs. `Get()` reports a function that resolved against no extension YAML the same way, returning empty `arg_types` however many arguments the call site passed — `md5(v)` has one and still arrives with none. Those are correctly bare today, and gating on `arg_types.empty()` alone would rename them too.

So `SubstraitCustomFunction::GetCompoundName()` always builds the compound form, as the type holding the signature, and `SubstraitFunctionExtensions::GetName()` picks between that and the bare name on `IsNative()`, as the type holding the extension path.

## Ingestion

Unaffected, but worth a pointer since the diff doesn't touch the consumer: the two new name forms reach DuckDB by different routes — `count:` through `RemoveExtension()`, `row_number:` through `RemapFunctionName()` — and both truncate at the first `:`.

`test_window.test` was producer-only, so the second route had no coverage. It now has round-trip tests asserting result values rather than names, which pins the semantics each name resolves to. Those pass before the fix as well — they guard the truncation path against a future regression rather than proving this change. The six new naming assertions are the ones that fail against a pre-fix build.

🤖 Generated with AI