### PR TITLE
docs: document the vcpkg prerequisites for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,28 @@ With this extension, DuckDB can produce Substrait plans from DuckDB queries as w
 
 ## Building
 
+### Prerequisites
+
+The extension consumes protobuf and the Substrait protobuf bindings from [vcpkg](https://vcpkg.io) (see [Updating the Substrait Version](#updating-the-substrait-version)), so the build needs a bootstrapped vcpkg checkout:
+
+```sh
+git clone https://github.com/microsoft/vcpkg.git ~/vcpkg
+~/vcpkg/bootstrap-vcpkg.sh
+```
+
+Clone in full rather than with `--depth=1`: vcpkg resolves the `builtin-baseline` from [`vcpkg.json`](vcpkg.json) against its own git history, and a shallow clone does not contain that commit. A package that ships only the `vcpkg` tool (such as Homebrew's `vcpkg`) is not enough either, as it provides no toolchain file.
+
+Then point `VCPKG_TOOLCHAIN_PATH` at that toolchain file, from a shell startup file so that new shells inherit it:
+
+```sh
+export VCPKG_ROOT=~/vcpkg
+export VCPKG_TOOLCHAIN_PATH=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
+```
+
+The build system passes `-DCMAKE_TOOLCHAIN_FILE` only when this variable is set. Without it, vcpkg never installs the dependencies and the configure step fails at `find_package(Protobuf CONFIG REQUIRED)` in [`CMakeLists.txt`](CMakeLists.txt).
+
+### Building the extension
+
 To build the extension, first clone this repository and initialize git submodules by running:
 
 ```sh
@@ -16,6 +38,8 @@ Then run:
 ```sh
 make
 ```
+
+If a configure already failed because `VCPKG_TOOLCHAIN_PATH` was unset, delete the `build` directory before retrying: CMake does not adopt a toolchain file into an existing cache.
 
 To use the newly-built extension, run the bundled `duckdb` shell:
 


### PR DESCRIPTION
Since #210 moved protobuf and the Substrait bindings to vcpkg, `make` only works if `VCPKG_TOOLCHAIN_PATH` is exported — the build system omits `-DCMAKE_TOOLCHAIN_FILE` when it is unset, and the configure then dies at `find_package(Protobuf CONFIG REQUIRED)`. The Building section still said "clone, init submodules, `make`", so this is a real onboarding trap: a contributor hit exactly that error this week and could not tell from the README what to set up.

Three failure modes the setup instructions call out, all of which look like the same error:

- `git clone --depth=1` does not contain the `builtin-baseline` commit, so vcpkg cannot resolve it.
- Packages that ship only the `vcpkg` tool (Homebrew's, for one) have no `scripts/buildsystems/vcpkg.cmake`.
- A build directory configured before the variable was set keeps failing, because CMake will not adopt a toolchain file into an existing cache.

Verified the diagnosis on macOS/arm64 with a throwaway project using this repo's `vcpkg.json` and `vcpkg-configuration.json`: without the toolchain file the `find_package` calls fail as reported, with it vcpkg installs the dependencies and both packages resolve.

🤖 Generated with AI